### PR TITLE
fix: remove 500/1000 item cap on library pagination

### DIFF
--- a/frontend/app/library/page.tsx
+++ b/frontend/app/library/page.tsx
@@ -112,21 +112,17 @@ export default function LibraryPage() {
         playTracks(formattedTracks, startIndex);
     };
 
-    // Shuffle entire library - fetches all tracks for true shuffle
+    // Shuffle entire library - uses server-side shuffle for large libraries
     const handleShuffleLibrary = async () => {
         try {
-            // Fetch a large batch of tracks for shuffling
-            const { tracks: allTracks } = await api.getTracks({
-                limit: 10000,
-            });
+            // Use server-side shuffle endpoint for better performance with large libraries
+            const { tracks: shuffledTracks } = await api.getShuffledTracks(500);
 
-            if (allTracks.length === 0) {
+            if (shuffledTracks.length === 0) {
                 return;
             }
 
-            // Shuffle the tracks
-            const shuffled = [...allTracks].sort(() => Math.random() - 0.5);
-            const formattedTracks = formatTracksForAudio(shuffled);
+            const formattedTracks = formatTracksForAudio(shuffledTracks);
             playTracks(formattedTracks, 0);
         } catch (error) {
             console.error("Failed to shuffle library:", error);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -402,6 +402,14 @@ class ApiClient {
         }>(`/library/tracks?${new URLSearchParams(params as any).toString()}`);
     }
 
+    async getShuffledTracks(limit?: number) {
+        const params = limit ? `?limit=${limit}` : "";
+        return this.request<{
+            tracks: any[];
+            total: number;
+        }>(`/library/tracks/shuffle${params}`);
+    }
+
     async deleteTrack(trackId: string) {
         return this.request<{ message: string }>(`/library/tracks/${trackId}`, {
             method: "DELETE",


### PR DESCRIPTION
## Summary

- Implements true server-side pagination for Artists, Albums, and Tracks
- Removes the 500-item display cap that prevented users with large libraries from browsing their full collection
- Adds `MAX_LIMIT = 10000` to prevent DoS while supporting large libraries
- Adds `trackCount` field to artists endpoint (fixes "Most Tracks" sort)
- Adds `/library/tracks/shuffle` endpoint for efficient server-side shuffle

## Changes

### Backend (`backend/src/routes/library.ts`)
- Added `MAX_LIMIT = 10000` constant applied to all endpoints
- `/library/artists`: Now includes `trackCount` for each artist
- `/library/albums`: Uses `MAX_LIMIT` cap
- `/library/tracks`: Added `offset` param and `total` in response, uses `MAX_LIMIT`
- **New** `/library/tracks/shuffle`: Server-side shuffle using Fisher-Yates algorithm

### Frontend
- `frontend/lib/api.ts`: Added `getShuffledTracks()` method
- `frontend/features/library/hooks/useLibraryData.ts`: Rewritten for server-side pagination
- `frontend/app/library/page.tsx`: Removed client-side slicing, uses server-side shuffle

## Test plan

- [ ] Import a library with 1000+ artists/albums/songs
- [ ] Verify total count shows correct number (e.g., "3,338 artists" not "500 artists")
- [ ] Navigate through pages - each page should load new items from API
- [ ] Test "Most Tracks" sort on Artists tab
- [ ] Test Shuffle button - should play random tracks from entire library
- [ ] Verify pagination buttons are disabled during loading

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)