### PR TITLE
Add GitHub registry deployment

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,11 +12,15 @@ on:
                 type: string
 
 env:
-    IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/lidify
+    DOCKERHUB_IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/lidify
+    GHCR_IMAGE_NAME: ghcr.io/${{ github.repository }}
 
 jobs:
     build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -40,6 +44,13 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Extract version
               id: version
               run: |
@@ -56,8 +67,10 @@ jobs:
                   file: ./Dockerfile
                   push: true
                   tags: |
-                      ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-                      ${{ env.IMAGE_NAME }}:latest
+                      ${{ env.DOCKERHUB_IMAGE_NAME }}:${{ steps.version.outputs.version }}
+                      ${{ env.DOCKERHUB_IMAGE_NAME }}:latest
+                      ${{ env.GHCR_IMAGE_NAME }}:${{ steps.version.outputs.version }}
+                      ${{ env.GHCR_IMAGE_NAME }}:latest
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
                   # Note: ARM64 removed due to QEMU emulation issues with npm packages


### PR DESCRIPTION
The docker registry has tight restrictions on pulling images, or even checking manifests that will cause you to eventually exceed their rate limit (unless you pay). GitHub's container registry is completely free for open source projects, and AFAIK has no significantly strict rate limiting for normal users.