### PR TITLE
Refactor: Fix playlist visibility toggle and state persistence

### DIFF
--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
+import { z } from "zod";
 import { requireAuthOrToken } from "../middleware/auth";
 import { prisma } from "../utils/db";
-import { z } from "zod";
 import { sessionLog } from "../utils/playlistLogger";
 
 const router = Router();
@@ -132,6 +132,10 @@ router.get("/:id", async (req, res) => {
                         username: true,
                     },
                 },
+                hiddenByUsers: {
+                    where: { userId },
+                    select: { id: true },
+                },
                 items: {
                     include: {
                         track: {
@@ -203,6 +207,7 @@ router.get("/:id", async (req, res) => {
         res.json({
             ...playlist,
             isOwner: playlist.userId === userId,
+            isHidden: playlist.hiddenByUsers.length > 0,
             trackCount: playlist.items.length,
             pendingCount: playlist.pendingTracks.length,
             items: formattedItems,

--- a/frontend/app/playlist/[id]/page.tsx
+++ b/frontend/app/playlist/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
     Pause,
     Trash2,
     Shuffle,
+    Eye,
     EyeOff,
     ListPlus,
     ListMusic,
@@ -195,10 +196,18 @@ export default function PlaylistDetailPage() {
             } else {
                 await api.hidePlaylist(playlistId);
             }
+
+            // Update local state immediately
+            queryClient.setQueryData(["playlist", playlistId], (old: any) => ({
+                ...old,
+                isHidden: !playlist.isHidden,
+            }));
+
             // Dispatch event to update sidebar and other components
             window.dispatchEvent(
                 new CustomEvent("playlist-updated", { detail: { playlistId } })
             );
+
             // Optionally navigate away if hiding
             if (!playlist.isHidden) {
                 router.push("/playlists");
@@ -532,7 +541,11 @@ export default function PlaylistDetailPage() {
                                 : "Hide playlist"
                         }
                     >
-                        <EyeOff className="w-5 h-5" />
+                        {playlist.isHidden ? (
+                            <Eye className="w-5 h-5" />
+                        ) : (
+                            <EyeOff className="w-5 h-5" />
+                        )}
                     </button>
 
                     {/* Delete Button */}


### PR DESCRIPTION
### Description
This PR addresses an issue where the "Hide/Show" playlist functionality was not correctly synchronizing between the backend state and the frontend UI.
**Changes:**
- **Backend (`routes/playlists.ts`):**
  - Updated `GET /playlists/:id` to include `hiddenByUsers` relation in the Prisma query.
  - Now returns a computed `isHidden` boolean field for the requesting user.
- **Frontend (`app/playlist/[id]/page.tsx`):**
  - Implemented the `Eye` icon for the "Show playlist" state.
  - Updated the toggle button logic to dynamically switch between "Hide" (`EyeOff`) and "Show" (`Eye`) based on the `isHidden` property.
  - Added optimistic UI updates using `queryClient.setQueryData` to immediately reflect visibility changes without requiring a page reload.
### Motivation
Previously, once a playlist was hidden, the UI did not provide a clear way to unhide it from the detail view because the state wasn't being correctly sent or updated. This ensures the user has full control over playlist visibility with immediate feedback.
### How to test
1. Open a playlist detail page.
2. Click the "Hide playlist" button (EyeOff icon).
3. Observe that the button immediately changes to "Show playlist" (Eye icon).
4. Verify that the playlist is hidden/shown correctly in the database/list.
