### PR TITLE
Add rudimentary OIDC support

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lidify-backend",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lidify-backend",
-            "version": "1.0.0",
+            "version": "1.2.0",
             "license": "GPL-3.0",
             "dependencies": {
                 "@bull-board/api": "^6.14.2",
@@ -4447,6 +4447,7 @@
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@prisma/engines": "5.22.0"
             },

--- a/backend/prisma/migrations/20260101015021_add_oidc_support/migration.sql
+++ b/backend/prisma/migrations/20260101015021_add_oidc_support/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "oidcId" TEXT,
+ADD COLUMN     "oidcUid" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,8 @@ model User {
   twoFactorRecoveryCodes String? // Recovery codes (encrypted, comma-separated hashed codes)
   moodMixParams          Json? // Saved mood mix parameters for "Your Mood Mix"
   createdAt              DateTime @default(now())
+  oidcId                 String? // The OIDC provider id
+  oidcUid                String? // The OIDC-specific user ID
 
   plays                Play[]
   playlists            Playlist[]
@@ -121,27 +123,27 @@ model SystemSettings {
 
   // === Download Preferences ===
   // Primary download source: "soulseek" (per-track) or "lidarr" (full albums)
-  downloadSource     String @default("soulseek")
+  downloadSource   String @default("soulseek")
   // When soulseek is primary and fails: "none" (skip) or "lidarr" (download full album)
-  soulseekFallback   String @default("none")
+  soulseekFallback String @default("none")
 
   updatedAt DateTime @updatedAt
   createdAt DateTime @default(now())
 }
 
 model Artist {
-  id                   String                   @id @default(cuid())
-  mbid                 String                   @unique
-  name                 String
-  normalizedName       String                   @default("") // Lowercase version for case-insensitive matching
-  summary              String?                  @db.Text
-  heroUrl              String?
-  genres               Json? // Array of genre strings from Last.fm/MusicBrainz
-  similarArtistsJson   Json? // Full Last.fm similar artists data [{name, mbid, match, image}]
-  lastSynced           DateTime                 @default(now())
-  lastEnriched         DateTime?
-  enrichmentStatus     String                   @default("pending") // pending, enriching, completed, failed
-  searchVector         Unsupported("tsvector")?
+  id                 String                   @id @default(cuid())
+  mbid               String                   @unique
+  name               String
+  normalizedName     String                   @default("") // Lowercase version for case-insensitive matching
+  summary            String?                  @db.Text
+  heroUrl            String?
+  genres             Json? // Array of genre strings from Last.fm/MusicBrainz
+  similarArtistsJson Json? // Full Last.fm similar artists data [{name, mbid, match, image}]
+  lastSynced         DateTime                 @default(now())
+  lastEnriched       DateTime?
+  enrichmentStatus   String                   @default("pending") // pending, enriching, completed, failed
+  searchVector       Unsupported("tsvector")?
 
   albums      Album[]
   similarFrom SimilarArtist[] @relation("FromArtist")
@@ -195,7 +197,7 @@ model Track {
   bpm        Float? // Beats per minute (e.g., 120.5)
   beatsCount Int? // Total beats in track
 
-  // Tonality  
+  // Tonality
   key         String? // Musical key (e.g., "C", "F#", "Bb")
   keyScale    String? // "major" or "minor"
   keyStrength Float? // Confidence 0-1
@@ -235,13 +237,13 @@ model Track {
   lastfmTags String[] // ["chill", "workout", "sad", "90s"]
 
   // Analysis Metadata
-  analysisStatus  String    @default("pending") // pending, processing, completed, failed
-  analysisVersion String? // Essentia version used
-  analysisMode    String? // 'standard' or 'enhanced'
-  analyzedAt      DateTime?
-  analysisError   String? // Error message if failed
-  analysisRetryCount Int @default(0) // Number of retry attempts
-  updatedAt       DateTime  @updatedAt
+  analysisStatus     String    @default("pending") // pending, processing, completed, failed
+  analysisVersion    String? // Essentia version used
+  analysisMode       String? // 'standard' or 'enhanced'
+  analyzedAt         DateTime?
+  analysisError      String? // Error message if failed
+  analysisRetryCount Int       @default(0) // Number of retry attempts
+  updatedAt          DateTime  @updatedAt
 
   album           Album            @relation(fields: [albumId], references: [id], onDelete: Cascade)
   plays           Play[]
@@ -314,15 +316,15 @@ model Playlist {
   name      String
   isPublic  Boolean  @default(false)
   createdAt DateTime @default(now())
-  
-  // Spotify import metadata
-  spotifyPlaylistId  String?  // Original Spotify playlist ID
-  spotifyPlaylistUrl String?  // Original Spotify URL for re-import
 
-  user           User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  items          PlaylistItem[]
-  pendingTracks  PlaylistPendingTrack[]
-  hiddenByUsers  HiddenPlaylist[]
+  // Spotify import metadata
+  spotifyPlaylistId  String? // Original Spotify playlist ID
+  spotifyPlaylistUrl String? // Original Spotify URL for re-import
+
+  user          User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  items         PlaylistItem[]
+  pendingTracks PlaylistPendingTrack[]
+  hiddenByUsers HiddenPlaylist[]
 
   @@unique([userId, mixId])
   @@index([userId])
@@ -361,13 +363,13 @@ model PlaylistItem {
 model PlaylistPendingTrack {
   id               String   @id @default(cuid())
   playlistId       String
-  spotifyArtist    String   // Original artist name from Spotify
-  spotifyTitle     String   // Original track title from Spotify
-  spotifyAlbum     String   // Original album name from Spotify
-  albumMbid        String?  // MusicBrainz album ID if resolved
-  artistMbid       String?  // MusicBrainz artist ID if resolved
-  deezerPreviewUrl String?  // Deezer 30s preview URL for playback while pending
-  sort             Int      // Position in original playlist
+  spotifyArtist    String // Original artist name from Spotify
+  spotifyTitle     String // Original track title from Spotify
+  spotifyAlbum     String // Original album name from Spotify
+  albumMbid        String? // MusicBrainz album ID if resolved
+  artistMbid       String? // MusicBrainz artist ID if resolved
+  deezerPreviewUrl String? // Deezer 30s preview URL for playback while pending
+  sort             Int // Position in original playlist
   createdAt        DateTime @default(now())
 
   playlist Playlist @relation(fields: [playlistId], references: [id], onDelete: Cascade)
@@ -380,22 +382,22 @@ model PlaylistPendingTrack {
 
 // Spotify Import Jobs - tracks import progress and state
 model SpotifyImportJob {
-  id                  String   @id
-  userId              String
-  spotifyPlaylistId   String
-  playlistName        String
-  status              String   // pending, downloading, scanning, creating_playlist, completed, failed, cancelled
-  progress            Int      @default(0) // 0-100
-  albumsTotal         Int
-  albumsCompleted     Int      @default(0)
-  tracksTotal         Int
-  tracksMatched       Int      @default(0)
-  tracksDownloadable  Int      @default(0)
-  createdPlaylistId   String?
-  error               String?
-  pendingTracks       Json     // Array of pending track objects
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  id                 String   @id
+  userId             String
+  spotifyPlaylistId  String
+  playlistName       String
+  status             String // pending, downloading, scanning, creating_playlist, completed, failed, cancelled
+  progress           Int      @default(0) // 0-100
+  albumsTotal        Int
+  albumsCompleted    Int      @default(0)
+  tracksTotal        Int
+  tracksMatched      Int      @default(0)
+  tracksDownloadable Int      @default(0)
+  createdPlaylistId  String?
+  error              String?
+  pendingTracks      Json // Array of pending track objects
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -464,12 +466,12 @@ model DownloadJob {
   discoveryBatchId String? // Links to Discovery Weekly batch if part of discovery
 
   // Release iteration tracking (for exhaustive retry)
-  triedReleases    String[]  @default([]) // GUIDs of releases we've tried
-  releaseIndex     Int       @default(0)   // Current position in release list
-  artistMbid       String?   // Artist MBID for same-artist fallback
-  cleared          Boolean   @default(false) // User dismissed from history
+  triedReleases String[] @default([]) // GUIDs of releases we've tried
+  releaseIndex  Int      @default(0) // Current position in release list
+  artistMbid    String? // Artist MBID for same-artist fallback
+  cleared       Boolean  @default(false) // User dismissed from history
 
-  user           User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   discoveryBatch DiscoveryBatch? @relation(fields: [discoveryBatchId], references: [id], onDelete: SetNull)
 
   @@index([userId, status])
@@ -785,8 +787,8 @@ model DiscoverExclusion {
   id              String   @id @default(cuid())
   userId          String
   albumMbid       String // MusicBrainz release group ID
-  artistName      String?  // For display purposes
-  albumTitle      String?  // For display purposes
+  artistName      String? // For display purposes
+  albumTitle      String? // For display purposes
   lastSuggestedAt DateTime @default(now())
   expiresAt       DateTime // 6 months from lastSuggestedAt
 
@@ -904,8 +906,8 @@ model DeviceLinkCode {
 model MoodBucket {
   id        String   @id @default(cuid())
   trackId   String
-  mood      String   // happy, sad, chill, energetic, party, focus, melancholy, aggressive, acoustic
-  score     Float    // Confidence score 0-1
+  mood      String // happy, sad, chill, energetic, party, focus, melancholy, aggressive, acoustic
+  score     Float // Confidence score 0-1
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -921,7 +923,7 @@ model MoodBucket {
 model UserMoodMix {
   id          String   @id @default(cuid())
   userId      String   @unique
-  mood        String   // The selected mood (happy, sad, etc.)
+  mood        String // The selected mood (happy, sad, etc.)
   trackIds    String[] // Cached track IDs for the mix
   coverUrls   String[] // Cached cover URLs for display
   generatedAt DateTime // When this mix was generated
@@ -962,10 +964,10 @@ enum AlbumLocation {
 model Notification {
   id        String   @id @default(cuid())
   userId    String
-  type      String   // system, download_complete, playlist_ready, error, import_complete
+  type      String // system, download_complete, playlist_ready, error, import_complete
   title     String
   message   String?
-  metadata  Json?    // { playlistId, albumId, artistId, etc. }
+  metadata  Json? // { playlistId, albumId, artistId, etc. }
   read      Boolean  @default(false)
   cleared   Boolean  @default(false)
   createdAt DateTime @default(now())

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -1,0 +1,68 @@
+export const AUTH_PROVIDERS = loadAuthProviders();
+
+export enum AuthType {
+    CREDENTIALS,
+    OIDC
+}
+
+export interface AuthProvider {
+    name: string;
+    type: AuthType;
+}
+
+export interface OidcProvider extends AuthProvider {
+    issuer: string;
+    clientId: string;
+    clientSecret: string;
+    roleField?: string;
+}
+
+function loadAuthProviders(): Map<string, AuthProvider> {
+    // Check for OIDC providers from environment variables
+    // Format: OIDC_PROVIDERS=keycloak:Keycloak SSO,authentik:Authentik
+
+    const providers = new Map<string, AuthProvider>();
+
+    if (process.env.DISABLE_CREDENTIALS_PROVIDER !== "true") {
+        providers.set("credentials", {
+            name: "Lidify",
+            type: AuthType.CREDENTIALS
+        });
+    }
+
+    const oidcProvidersEnv = process.env.OIDC_PROVIDERS;
+    if (oidcProvidersEnv) {
+        const oidcProvidersList = oidcProvidersEnv.split(',').map(p => p.trim());
+        for (const provider of oidcProvidersList) {
+            const [id, name] = provider.split(':');
+            if (id && name) {
+                // These IDs need to be unique
+                if (providers.has(id)) {
+                    throw new Error(`Duplicate OIDC provider id found: ${id}`);
+                }
+                // Check if the provider has required env vars
+                const hasConfig = process.env[`OIDC_${id.toUpperCase()}_ISSUER`] &&
+                    process.env[`OIDC_${id.toUpperCase()}_CLIENT_ID`] &&
+                    process.env[`OIDC_${id.toUpperCase()}_CLIENT_SECRET`];
+                if (!hasConfig) {
+                    throw new Error(`Missing configuration for OIDC provider: ${id}`);
+                }
+
+                providers.set(id, {
+                    name,
+                    type: AuthType.OIDC,
+                    issuer: process.env[`OIDC_${id.toUpperCase()}_ISSUER`],
+                    clientId: process.env[`OIDC_${id.toUpperCase()}_CLIENT_ID`],
+                    clientSecret: process.env[`OIDC_${id.toUpperCase()}_CLIENT_SECRET`],
+                    roleField: process.env[`OIDC_${id.toUpperCase()}_ROLE_FIELD`],
+                } as OidcProvider);
+            }
+        }
+    }
+
+    if (providers.size === 0) {
+        throw new Error("No authentication providers configured");
+    }
+
+    return providers;
+}

--- a/backend/src/utils/db.ts
+++ b/backend/src/utils/db.ts
@@ -1,3 +1,35 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, User } from '@prisma/client';
 
 export const prisma = new PrismaClient();
+
+export async function createUser(username: string, passwordHash: string, role?: string, providerId?: string, oidcUid?: string): Promise<User> {
+    const user = await prisma.user.create({
+        data: {
+            username,
+            passwordHash,
+            role: role || "user",
+            onboardingComplete: true, // Skip onboarding for created users
+            oidcId: providerId,
+            oidcUid: oidcUid,
+        },
+    });
+
+    // Create default user settings
+    await prisma.userSettings.create({
+        data: {
+            userId: user.id,
+            playbackQuality: "original",
+            wifiOnly: false,
+            offlineEnabled: false,
+            maxCacheSizeMb: 10240,
+        },
+    });
+    return user;
+}
+
+export async function updateUserRole(username: string, role: string): Promise<void> {
+    await prisma.user.update({
+        where: { username },
+        data: { role },
+    });
+}

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -1,0 +1,126 @@
+# OIDC Authentication
+
+Lidify supports Single Sign-On (SSO) using OIDC, allowing you to login with your existing identity provider.
+
+## Supported Providers
+
+Keycloak, Authentik, Authelia, Azure AD, Auth0, Okta, and any OIDC-compliant provider.
+
+## Setup
+
+### 1. Configure Your Provider
+
+Add this callback URL to your OIDC provider:
+
+```
+http://localhost:3030/auth/callback        # Development
+https://music.example.com/auth/callback    # Production
+```
+
+### 2. Configure Lidify
+
+Add to your `docker-compose.yml`:
+
+```yaml
+environment:
+  OIDC_PROVIDERS: keycloak:Keycloak SSO
+  OIDC_KEYCLOAK_ISSUER: https://auth.example.com/realms/myrealm
+  OIDC_KEYCLOAK_CLIENT_ID: lidify
+  OIDC_KEYCLOAK_CLIENT_SECRET: your-secret-here
+```
+
+### 3. Restart
+
+> :warning: **Users with matching usernames will login to existing accounts.**
+
+```bash
+docker-compose restart
+```
+
+## Configuration Options
+
+| Variable | Description |
+|----------|-------------|
+| `OIDC_PROVIDERS` | List of `id:name` pairs (comma-separated) |
+| `OIDC_<ID>_ISSUER` | Provider URL |
+| `OIDC_<ID>_CLIENT_ID` | OAuth client ID |
+| `OIDC_<ID>_CLIENT_SECRET` | OAuth client secret |
+| `OIDC_<ID>_ROLE_FIELD` | OIDC claim field for roles (optional) |
+| `DISABLE_CREDENTIALS_PROVIDER` | Set to `true` to hide username/password login |
+
+Replace `<ID>` with your provider ID in UPPERCASE (e.g., `KEYCLOAK`).
+
+## Role Mapping
+
+By default, OIDC users get the "user" role. To assign roles from your OIDC provider:
+
+```yaml
+OIDC_KEYCLOAK_ROLE_FIELD: roles
+```
+
+Common values (top-level claims only; nested paths like `realm_access.roles` or `resource_access.lidify.roles` are not currently supported directly and must be mapped to a top-level claim in your provider):
+- `roles` - Simple roles claim
+- `groups` - Groups/AD groups
+  Your OIDC provider must include this top-level field in its userinfo response.
+
+Your OIDC provider must include this field in its userinfo response.
+
+## Multiple Providers
+
+```yaml
+OIDC_PROVIDERS: keycloak:Company SSO,authentik:Partner SSO
+OIDC_KEYCLOAK_ISSUER: https://keycloak.example.com/realms/master
+OIDC_KEYCLOAK_CLIENT_ID: lidify
+OIDC_KEYCLOAK_CLIENT_SECRET: secret1
+OIDC_AUTHENTIK_ISSUER: https://auth.partner.com/application/o/lidify
+OIDC_AUTHENTIK_CLIENT_ID: lidify
+OIDC_AUTHENTIK_CLIENT_SECRET: secret2
+```
+
+## Provider Examples
+
+### Keycloak
+
+1. Create client with:
+   - Client ID: `lidify`
+   - Access Type: `confidential`
+   - Valid Redirect URIs: `http://localhost:3030/auth/callback*`
+   - Standard Flow: Enabled
+
+2. Copy client secret from Credentials tab
+
+3. Issuer URL: `https://keycloak.example.com/realms/your-realm`
+
+### Azure AD
+
+1. Register app as "Single-page application"
+2. Set redirect URI: `http://localhost:3030/auth/callback`
+3. Add permissions: `openid`, `profile`, `email`
+4. Create client secret
+5. Issuer URL: `https://login.microsoftonline.com/{TENANT_ID}/v2.0`
+
+### Authentik
+
+1. Create OAuth2/OpenID Provider
+2. Set redirect URI: `http://localhost:3030/auth/callback`
+3. Copy client ID and secret
+4. Issuer URL: `https://authentik.example.com/application/o/lidify/`
+
+## Troubleshooting
+
+**Login loops**: Check backend logs and verify the issuer URL exactly matches your provider’s configuration (including whether it requires a trailing slash; e.g. Authentik does)
+
+**"No authorization code"**: Verify callback URL matches exactly in provider config
+
+**"code_verifier mismatch"**: Clear browser localStorage and try again
+
+**"No field for role"**: Either remove `ROLE_FIELD` or add the claim to your OIDC provider
+
+**Backend logs**: `docker-compose logs -f backend`
+
+## Migration from Password Login
+
+1. Add OIDC config (keep credentials enabled)
+2. Test OIDC login works
+3. Set `DISABLE_CREDENTIALS_PROVIDER=true`
+4. Restart

--- a/frontend/app/auth/callback/[id]/page.tsx
+++ b/frontend/app/auth/callback/[id]/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { use, useEffect, useRef, useState } from "react";
+import { LoadingScreen } from "@/components/ui/LoadingScreen";
+import { api } from "@/lib/api";
+import { handleOIDCCallback } from "@/lib/auth/oidc-client";
+
+interface AuthCallbackProps {
+    params: Promise<{
+        id: string;
+    }>;
+}
+
+export default function AuthCallbackPage({ params }: AuthCallbackProps) {
+    const [error, setError] = useState<string | null>(null);
+    const hasStartedRef = useRef(false);
+    const { id } = use(params);
+
+    useEffect(() => {
+        // Prevent running twice
+        if (hasStartedRef.current) {
+            return;
+        }
+        hasStartedRef.current = true;
+
+        const processCallback = async () => {
+            try {
+                // Handle OIDC callback and get Lidify JWT
+                const token = await handleOIDCCallback(id);
+
+                api.setToken(token);
+
+                window.location.href = "/";
+            } catch (error: any) {
+                console.error("[OIDC Callback] Error:", error);
+                setError(error.message);
+
+                // Wait 3 seconds before redirecting
+                await new Promise(resolve => setTimeout(resolve, 3000));
+                window.location.href = "/login?error=Authentication%20failed";
+            }
+        };
+
+        processCallback();
+    }, []);
+
+    if (error) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-black">
+                <div className="text-red-500">Error: {error}</div>
+            </div>
+        );
+    }
+
+    return <LoadingScreen />;
+}

--- a/frontend/app/login/credentials/page.tsx
+++ b/frontend/app/login/credentials/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth-context";
+import { Loader2, ArrowLeft } from "lucide-react";
+import { AuthPageTemplate } from "@/components/auth/AuthPageTemplate";
+import Link from "next/link";
+
+// Separate component to handle search params (needs Suspense boundary)
+function LoginErrorHandler({
+    setError,
+}: {
+    setError: (error: string) => void;
+}) {
+    const searchParams = useSearchParams();
+
+    useEffect(() => {
+        const errorParam = searchParams.get("error");
+        if (errorParam) {
+            setError(decodeURIComponent(errorParam));
+        }
+    }, [searchParams, setError]);
+
+    return null;
+}
+
+export default function CredentialsLoginPage() {
+    const { login } = useAuth();
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+    const [twoFactorToken, setTwoFactorToken] = useState("");
+    const [requires2FA, setRequires2FA] = useState(false);
+    const [useRecoveryCode, setUseRecoveryCode] = useState(false);
+    const [error, setError] = useState("");
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError("");
+        setIsSubmitting(true);
+
+        try {
+            await login(username, password, twoFactorToken || undefined);
+        } catch (err: any) {
+            if (err.message === "2FA token required") {
+                setRequires2FA(true);
+                setError("");
+            } else {
+                setError(err.message || "Invalid credentials");
+            }
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <AuthPageTemplate
+            title={requires2FA ? "Two-Factor Authentication" : "Sign in with credentials"}
+            subtitle={requires2FA ? "Enter your verification code" : "Enter your username and password"}
+        >
+            <Suspense fallback={null}>
+                <LoginErrorHandler setError={setError} />
+            </Suspense>
+
+            <div className="w-full max-w-md mx-auto">
+                {/* Back to provider selection */}
+                <Link
+                    href="/login"
+                    className="inline-flex items-center gap-2 text-sm text-gray-400 hover:text-white mb-6 transition-colors"
+                >
+                    <ArrowLeft className="w-4 h-4" />
+                    Back to login options
+                </Link>
+
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    {error && (
+                        <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
+                            {error}
+                        </div>
+                    )}
+
+                    {!requires2FA ? (
+                        <>
+                            <div>
+                                <label
+                                    htmlFor="username"
+                                    className="block text-sm font-medium text-gray-300 mb-2"
+                                >
+                                    Username
+                                </label>
+                                <input
+                                    id="username"
+                                    type="text"
+                                    value={username}
+                                    onChange={(e) => setUsername(e.target.value)}
+                                    className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#ecb200] focus:border-transparent transition-all"
+                                    placeholder="Enter your username"
+                                    required
+                                    autoComplete="username"
+                                />
+                            </div>
+
+                            <div>
+                                <label
+                                    htmlFor="password"
+                                    className="block text-sm font-medium text-gray-300 mb-2"
+                                >
+                                    Password
+                                </label>
+                                <input
+                                    id="password"
+                                    type="password"
+                                    value={password}
+                                    onChange={(e) => setPassword(e.target.value)}
+                                    className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#ecb200] focus:border-transparent transition-all"
+                                    placeholder="Enter your password"
+                                    required
+                                    autoComplete="current-password"
+                                />
+                            </div>
+                        </>
+                    ) : (
+                        <div>
+                            <label
+                                htmlFor="token"
+                                className="block text-sm font-medium text-gray-300 mb-2"
+                            >
+                                {useRecoveryCode ? "Recovery Code" : "Verification Code"}
+                            </label>
+                            <input
+                                id="token"
+                                type="text"
+                                value={twoFactorToken}
+                                onChange={(e) => setTwoFactorToken(e.target.value)}
+                                className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#ecb200] focus:border-transparent transition-all text-center text-2xl tracking-widest"
+                                placeholder={useRecoveryCode ? "XXXXX-XXXXX" : "000000"}
+                                required
+                                autoComplete="one-time-code"
+                                autoFocus
+                            />
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setUseRecoveryCode(!useRecoveryCode);
+                                    setTwoFactorToken("");
+                                }}
+                                className="mt-2 text-sm text-[#ecb200] hover:text-[#d4a000] transition-colors"
+                            >
+                                {useRecoveryCode
+                                    ? "Use authenticator code instead"
+                                    : "Use recovery code instead"}
+                            </button>
+                        </div>
+                    )}
+
+                    <button
+                        type="submit"
+                        disabled={isSubmitting}
+                        className="w-full px-6 py-3 bg-[#ecb200] hover:bg-[#d4a000] text-black font-semibold rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                    >
+                        {isSubmitting ? (
+                            <>
+                                <Loader2 className="w-5 h-5 animate-spin" />
+                                Signing in...
+                            </>
+                        ) : (
+                            "Sign in"
+                        )}
+                    </button>
+                </form>
+            </div>
+        </AuthPageTemplate>
+    );
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -2,18 +2,10 @@
 
 import { useState, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
-import { useAuth } from "@/lib/auth-context";
-import Image from "next/image";
-import { Loader2 } from "lucide-react";
-import { GalaxyBackground } from "@/components/ui/GalaxyBackground";
-
-interface Artist {
-    id: string;
-    mbid?: string;
-    name: string;
-    heroUrl: string | null;
-    albumCount?: number;
-}
+import { AUTH_PROVIDERS, AuthProvider, startOIDCLogin } from "@/lib/auth/oidc-client";
+import { Loader2, Key } from "lucide-react";
+import { AuthPageTemplate } from "@/components/auth/AuthPageTemplate";
+import Link from "next/link";
 
 // Separate component to handle search params (needs Suspense boundary)
 function LoginErrorHandler({
@@ -34,377 +26,141 @@ function LoginErrorHandler({
 }
 
 export default function LoginPage() {
-    const { login } = useAuth();
-    const [username, setUsername] = useState("");
-    const [password, setPassword] = useState("");
-    const [twoFactorToken, setTwoFactorToken] = useState("");
-    const [requires2FA, setRequires2FA] = useState(false);
-    const [useRecoveryCode, setUseRecoveryCode] = useState(false);
+    const [providers, setProviders] = useState<AuthProvider[]>([]);
     const [error, setError] = useState("");
-    const [isLoading, setIsLoading] = useState(false);
-    const [artists, setArtists] = useState<Artist[]>([]);
-    const [currentArtistIndex, setCurrentArtistIndex] = useState(0);
+    const [isLoading, setIsLoading] = useState(true);
 
-    // Fetch featured artists for background rotation
+    // Fetch providers on mount
     useEffect(() => {
-        const fetchArtists = async () => {
+        const fetchProviders = async () => {
             try {
-                // Get recently listened artists (public endpoint or cached data)
-                const response = await fetch(
-                    "/api/library/recently-listened?limit=10"
-                );
-                if (response.ok) {
-                    const data = await response.json();
-                    const artistsWithImages = data.artists.filter(
-                        (a: Artist) => a.heroUrl
-                    );
-                    setArtists(
-                        artistsWithImages.length > 0 ? artistsWithImages : []
-                    );
+                const authProviders = await AUTH_PROVIDERS;
+                setProviders(authProviders);
+
+                // Auto-redirect based on available providers
+                const oidcProviders = authProviders.filter((p: AuthProvider) => p.type === "oidc");
+                const credentialsProvider = authProviders.find((p: AuthProvider) => p.type === "credentials");
+
+                // If only credentials, redirect to credentials page
+                if (credentialsProvider && oidcProviders.length === 0) {
+                    // Provide user feedback before redirecting
+                    setError("Redirecting to credentials login...");
+                    window.location.href = "/login/credentials";
+                    return;
                 }
-                // Silently ignore errors (expected when not authenticated)
+
+                // If only one OIDC provider and no credentials, auto-start OIDC flow
+                if (oidcProviders.length === 1 && !credentialsProvider) {
+                    // Provide user feedback before starting OIDC login
+                    setError("Redirecting to SSO login...");
+                    await startOIDCLogin(oidcProviders[0]);
+                    return;
+                }
             } catch (err) {
-                // Fail silently - login page will work without backgrounds
+                console.error("Failed to fetch providers:", err);
+            } finally {
+                setIsLoading(false);
             }
         };
 
-        fetchArtists();
+        fetchProviders();
     }, []);
 
-    // Rotate through artists every 5 seconds
-    useEffect(() => {
-        if (artists.length <= 1) return;
-
-        const interval = setInterval(() => {
-            setCurrentArtistIndex((prev) => (prev + 1) % artists.length);
-        }, 5000);
-
-        return () => clearInterval(interval);
-    }, [artists.length]);
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setError("");
-        setIsLoading(true);
-
+    const handleOIDCLogin = async (provider: AuthProvider) => {
         try {
-            // First step: Send username and password
-            if (!requires2FA) {
-                await login(username, password);
-                // If we get here, either:
-                // 1. Login succeeded (no 2FA)
-                // 2. We'll catch the requires2FA response below
-            } else {
-                // Second step: Send 2FA token
-                await login(username, password, twoFactorToken);
-                // If successful, login() will redirect
-            }
+            await startOIDCLogin(provider);
         } catch (err) {
-            const errorMsg =
-                err instanceof Error ? err.message : "Login failed";
-
-            // Check if 2FA is required
-            if (
-                errorMsg.includes("2FA token required") ||
-                errorMsg.includes("requires2FA")
-            ) {
-                setRequires2FA(true);
-                setError("");
-            } else if (
-                errorMsg.includes("Invalid 2FA token") ||
-                errorMsg.includes("Invalid recovery code")
-            ) {
-                setError(errorMsg);
-                setTwoFactorToken(""); // Clear the token for retry
-            } else {
-                setError(errorMsg);
-                setRequires2FA(false);
-                setTwoFactorToken("");
-            }
-        } finally {
-            setIsLoading(false);
+            console.error("OIDC login failed:", err);
+            const message =
+                err instanceof Error && err.message ? err.message : String(err);
+            setError(`Failed to start OIDC login: ${message}`);
         }
     };
 
-    const currentArtist = artists[currentArtistIndex];
+    if (isLoading) {
+        return (
+            <AuthPageTemplate
+                title="Loading..."
+                subtitle="Please wait"
+                showArtistBackground={false}
+            >
+                <div className="flex justify-center py-8">
+                    <Loader2 className="w-8 h-8 text-white animate-spin" />
+                </div>
+            </AuthPageTemplate>
+        );
+    }
+
+    const oidcProviders = providers.filter(p => p.type === "oidc");
+    const hasCredentials = providers.some(p => p.type === "credentials");
 
     return (
-        <div className="min-h-screen w-full relative overflow-hidden">
-            {/* Handle error from URL params */}
+        <AuthPageTemplate
+            title="Sign in to Lidify"
+            subtitle="Choose your authentication method"
+        >
             <Suspense fallback={null}>
                 <LoginErrorHandler setError={setError} />
             </Suspense>
 
-            {/* Animated Background with Artist Images */}
-            <div className="absolute inset-0 bg-[#000]">
-                {/* Subtle accent gradient */}
-                <div className="absolute inset-0 bg-gradient-to-br from-[#fca200]/5 via-transparent to-transparent" />
+            <div className="w-full max-w-md mx-auto space-y-4">
+                {error && (
+                    <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
+                        {error}
+                    </div>
+                )}
 
-                {/* Ultra-subtle starfield texture (dialed down vs the main app) */}
-                <div className="opacity-[0.08]">
-                    <GalaxyBackground
-                        primaryColor="#fca200"
-                        secondaryColor="#fca200"
-                    />
-                </div>
+                {/* OIDC Providers */}
+                {oidcProviders.length > 0 && (
+                    <div className="space-y-3">
+                        {oidcProviders.map((provider) => (
+                            <button
+                                key={provider.id}
+                                onClick={() => handleOIDCLogin(provider)}
+                                className="w-full px-6 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-[#ecb200]/50 text-white font-semibold rounded-lg transition-all flex items-center justify-center gap-3 group"
+                            >
+                                <svg
+                                    className="w-5 h-5 text-[#ecb200]"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 24 24"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+                                    />
+                                </svg>
+                                {provider.name}
+                            </button>
+                        ))}
+                    </div>
+                )}
 
-                {artists.length > 0 && currentArtist?.heroUrl && (
-                    <>
-                        <div
-                            key={currentArtistIndex}
-                            className="absolute inset-0 transition-opacity duration-1000"
-                        >
-                            <Image
-                                src={currentArtist.heroUrl}
-                                alt={currentArtist.name}
-                                fill
-                                className="object-cover"
-                                priority
-                            />
+                {/* Divider */}
+                {oidcProviders.length > 0 && hasCredentials && (
+                    <div className="relative py-4">
+                        <div className="absolute inset-0 flex items-center">
+                            <div className="w-full border-t border-white/10"></div>
                         </div>
-                        {/* Heavy blur overlay */}
-                        <div className="absolute inset-0 backdrop-blur-[100px] bg-black/60" />
+                        <div className="relative flex justify-center text-sm">
+                            <span className="px-4 bg-black text-gray-400">Or</span>
+                        </div>
+                    </div>
+                )}
 
-                        {/* Gradient overlays for depth */}
-                        <div className="absolute inset-0 bg-gradient-to-t from-black via-black/50 to-transparent" />
-                        <div className="absolute inset-0 bg-gradient-to-b from-black/80 via-transparent to-black/80" />
-                    </>
+                {/* Credentials Option */}
+                {hasCredentials && (
+                    <Link
+                        href="/login/credentials"
+                        className="w-full px-6 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-[#ecb200]/50 text-white font-semibold rounded-lg transition-all flex items-center justify-center gap-3 group"
+                    >
+                        <Key className="w-5 h-5 text-[#ecb200]" />
+                        Lidify
+                    </Link>
                 )}
             </div>
-
-            {/* Artist Info Section - Bottom Left */}
-            {currentArtist && (
-                <div className="absolute bottom-8 left-8 z-10 text-white max-w-md animate-fade-in">
-                    <p className="text-sm font-medium text-white/60 mb-2">
-                        Featured Artist
-                    </p>
-                    <h2 className="text-3xl md:text-4xl font-bold mb-2 drop-shadow-2xl">
-                        {currentArtist.name}
-                    </h2>
-                    {currentArtist.albumCount !== undefined && (
-                        <p className="text-white/70 text-sm">
-                            {currentArtist.albumCount} album
-                            {currentArtist.albumCount !== 1 ? "s" : ""} in your
-                            library
-                        </p>
-                    )}
-                </div>
-            )}
-
-            {/* Login Form - Centered */}
-            <div className="relative z-20 min-h-screen flex items-center justify-center p-4">
-                <div className="w-full max-w-md">
-                    {/* Logo */}
-                    <div className="flex items-center justify-center mb-8">
-                        <div className="relative flex gap-3 items-center group">
-                            <div className="relative">
-                                <div className="absolute inset-0 bg-white/10 blur-xl rounded-full group-hover:bg-white/20 transition-all duration-300" />
-                                <Image
-                                    src="/assets/images/LIDIFY.webp"
-                                    alt="Lidify"
-                                    width={40}
-                                    height={40}
-                                    className="relative z-10 drop-shadow-2xl"
-                                />
-                            </div>
-                            <span className="text-3xl font-bold bg-gradient-to-r from-white via-white to-gray-200 bg-clip-text text-transparent drop-shadow-2xl">
-                                Lidify
-                            </span>
-                        </div>
-                    </div>
-
-                    {/* Login Card */}
-                    <div className="bg-[#111]/90 rounded-lg p-6 md:p-8 border border-white/10 shadow-xl ">
-                        <h1 className="text-2xl font-bold text-white mb-1 text-center">
-                            Welcome back
-                        </h1>
-                        <p className="text-white/60 text-center mb-8">
-                            Sign in to continue to Lidify
-                        </p>
-
-                        <form onSubmit={handleSubmit} className="space-y-4">
-                            {error && (
-                                <div className="bg-red-500/10  border border-red-500/30 rounded-lg p-4 text-sm text-red-400 animate-shake">
-                                    {error}
-                                </div>
-                            )}
-
-                            {/* Step 1: Username & Password */}
-                            {!requires2FA && (
-                                <>
-                                    <div>
-                                        <label
-                                            htmlFor="username"
-                                            className="block text-sm font-medium text-white/90 mb-1.5"
-                                        >
-                                            Username
-                                        </label>
-                                        <input
-                                            id="username"
-                                            type="text"
-                                            value={username}
-                                            onChange={(e) =>
-                                                setUsername(e.target.value)
-                                            }
-                                            placeholder="Enter your username"
-                                            required
-                                            autoFocus
-                                            autoCapitalize="none"
-                                            autoCorrect="off"
-                                            className="w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-brand/30 focus:border-transparent transition-all duration-200 "
-                                        />
-                                    </div>
-
-                                    <div>
-                                        <label
-                                            htmlFor="password"
-                                            className="block text-sm font-medium text-white/90 mb-1.5"
-                                        >
-                                            Password
-                                        </label>
-                                        <input
-                                            id="password"
-                                            type="password"
-                                            value={password}
-                                            onChange={(e) =>
-                                                setPassword(e.target.value)
-                                            }
-                                            placeholder="Enter your password"
-                                            required
-                                            autoCapitalize="none"
-                                            autoCorrect="off"
-                                            className="w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-brand/30 focus:border-transparent transition-all duration-200 "
-                                        />
-                                    </div>
-                                </>
-                            )}
-
-                            {/* Step 2: 2FA Token Input */}
-                            {requires2FA && (
-                                <div className="animate-fade-in space-y-4">
-                                    <div className="p-4 bg-brand/10 border border-brand/20 rounded-lg">
-                                        <p className="text-white/90 text-sm font-semibold mb-1">
-                                            Two-Factor Authentication Required
-                                        </p>
-                                        <p className="text-white/60 text-xs">
-                                            Logging in as{" "}
-                                            <strong>{username}</strong>
-                                        </p>
-                                    </div>
-                                    <div>
-                                        <label
-                                            htmlFor="twoFactorToken"
-                                            className="block text-sm font-medium text-white/90 mb-1.5"
-                                        >
-                                            {useRecoveryCode
-                                                ? "Recovery Code"
-                                                : "Authentication Code"}
-                                        </label>
-                                        <input
-                                            id="twoFactorToken"
-                                            type="text"
-                                            value={twoFactorToken}
-                                            onChange={(e) => {
-                                                if (useRecoveryCode) {
-                                                    // Recovery code: 8 hex characters
-                                                    setTwoFactorToken(
-                                                        e.target.value
-                                                            .replace(
-                                                                /[^A-Fa-f0-9]/g,
-                                                                ""
-                                                            )
-                                                            .slice(0, 8)
-                                                            .toUpperCase()
-                                                    );
-                                                } else {
-                                                    // TOTP: 6 digits
-                                                    setTwoFactorToken(
-                                                        e.target.value
-                                                            .replace(/\D/g, "")
-                                                            .slice(0, 6)
-                                                    );
-                                                }
-                                            }}
-                                            placeholder={
-                                                useRecoveryCode
-                                                    ? "ABCD1234"
-                                                    : "000000"
-                                            }
-                                            maxLength={useRecoveryCode ? 8 : 6}
-                                            required
-                                            autoFocus
-                                            autoCapitalize="none"
-                                            autoCorrect="off"
-                                            className="w-full px-4 py-2.5 bg-white/5 border border-brand/30 rounded-lg text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-transparent transition-all duration-200  text-center text-2xl tracking-widest"
-                                        />
-                                        <p className="text-xs text-white/50 mt-2">
-                                            {useRecoveryCode
-                                                ? "Enter your 8-character recovery code"
-                                                : "Enter the 6-digit code from your authenticator app"}
-                                        </p>
-                                    </div>
-
-                                    {/* Toggle between TOTP and Recovery Code */}
-                                    <div className="flex items-center justify-center">
-                                        <button
-                                            type="button"
-                                            onClick={() => {
-                                                setUseRecoveryCode(
-                                                    !useRecoveryCode
-                                                );
-                                                setTwoFactorToken("");
-                                                setError("");
-                                            }}
-                                            className="text-xs text-brand hover:text-brand-light transition-colors underline"
-                                        >
-                                            {useRecoveryCode
-                                                ? "Use authenticator app instead"
-                                                : "Use recovery code instead"}
-                                        </button>
-                                    </div>
-                                </div>
-                            )}
-
-                            <button
-                                type="submit"
-                                disabled={isLoading}
-                                className="w-full py-3 bg-[#fca200] text-black font-bold rounded-lg hover:bg-[#e69200] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-                            >
-                                <span className="flex items-center justify-center gap-2">
-                                    {isLoading ? (
-                                        <>
-                                            <Loader2 className="w-5 h-5 animate-spin" />
-                                            Signing in...
-                                        </>
-                                    ) : (
-                                        "Sign In"
-                                    )}
-                                </span>
-                            </button>
-
-                            {requires2FA && (
-                                <button
-                                    type="button"
-                                    onClick={() => {
-                                        setRequires2FA(false);
-                                        setTwoFactorToken("");
-                                        setUseRecoveryCode(false);
-                                        setError("");
-                                    }}
-                                    className="w-full text-xs text-white/50 hover:text-white/80 transition-colors"
-                                >
-                                    ← Back to login
-                                </button>
-                            )}
-                        </form>
-                    </div>
-
-                    {/* Footer */}
-                    <p className="text-center text-white/40 text-sm mt-6">
-                        © 2025 Lidify. Your music, your way.
-                    </p>
-                </div>
-            </div>
-        </div>
+        </AuthPageTemplate>
     );
 }

--- a/frontend/components/auth/AuthPageTemplate.tsx
+++ b/frontend/components/auth/AuthPageTemplate.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { ReactNode, useState, useEffect } from "react";
+import Image from "next/image";
+import { GalaxyBackground } from "@/components/ui/GalaxyBackground";
+
+interface Artist {
+    id: string;
+    mbid?: string;
+    name: string;
+    heroUrl: string | null;
+    albumCount?: number;
+}
+
+interface AuthPageTemplateProps {
+    title: string;
+    subtitle: string;
+    children: ReactNode;
+    showArtistBackground?: boolean;
+}
+
+export function AuthPageTemplate({
+    title,
+    subtitle,
+    children,
+    showArtistBackground = true,
+}: AuthPageTemplateProps) {
+    const [artists, setArtists] = useState<Artist[]>([]);
+    const [currentArtistIndex, setCurrentArtistIndex] = useState(0);
+
+    // Fetch featured artists for background rotation
+    useEffect(() => {
+        if (!showArtistBackground) return;
+
+        const fetchArtists = async () => {
+            try {
+                const response = await fetch(
+                    "/api/library/recently-listened?limit=10"
+                );
+                if (response.ok) {
+                    const data = await response.json();
+                    const artistsWithImages = data.artists.filter(
+                        (a: Artist) => a.heroUrl
+                    );
+                    setArtists(
+                        artistsWithImages.length > 0 ? artistsWithImages : []
+                    );
+                }
+            } catch (err) {
+                // Fail silently - page will work without backgrounds
+            }
+        };
+
+        fetchArtists();
+    }, [showArtistBackground]);
+
+    // Rotate through artists every 5 seconds
+    useEffect(() => {
+        if (artists.length <= 1) return;
+
+        const interval = setInterval(() => {
+            setCurrentArtistIndex((prev) => (prev + 1) % artists.length);
+        }, 5000);
+
+        return () => clearInterval(interval);
+    }, [artists.length]);
+
+    const currentArtist = artists[currentArtistIndex];
+
+    return (
+        <div className="min-h-screen w-full relative overflow-hidden">
+            {/* Animated Background with Artist Images */}
+            <div className="absolute inset-0 bg-[#000]">
+                {/* Subtle accent gradient */}
+                <div className="absolute inset-0 bg-gradient-to-br from-[#fca200]/5 via-transparent to-transparent" />
+
+                {/* Ultra-subtle starfield texture */}
+                <div className="opacity-[0.08]">
+                    <GalaxyBackground
+                        primaryColor="#fca200"
+                        secondaryColor="#fca200"
+                    />
+                </div>
+
+                {showArtistBackground && artists.length > 0 && currentArtist?.heroUrl && (
+                    <>
+                        <div
+                            key={currentArtistIndex}
+                            className="absolute inset-0 transition-opacity duration-1000"
+                        >
+                            <Image
+                                src={currentArtist.heroUrl}
+                                alt={currentArtist.name}
+                                fill
+                                className="object-cover"
+                                priority
+                            />
+                        </div>
+                        {/* Heavy blur overlay */}
+                        <div className="absolute inset-0 backdrop-blur-[100px] bg-black/60" />
+
+                        {/* Gradient overlays for depth */}
+                        <div className="absolute inset-0 bg-gradient-to-t from-black via-black/50 to-transparent" />
+                        <div className="absolute inset-0 bg-gradient-to-b from-black/80 via-transparent to-black/80" />
+                    </>
+                )}
+            </div>
+
+            {/* Artist Info Section - Bottom Left */}
+            {showArtistBackground && currentArtist && (
+                <div className="absolute bottom-8 left-8 z-10 text-white max-w-md animate-fade-in">
+                    <p className="text-sm font-medium text-white/60 mb-2">
+                        Featured Artist
+                    </p>
+                    <h2 className="text-3xl md:text-4xl font-bold mb-2 drop-shadow-2xl">
+                        {currentArtist.name}
+                    </h2>
+                    {currentArtist.albumCount !== undefined && (
+                        <p className="text-white/70 text-sm">
+                            {currentArtist.albumCount} album
+                            {currentArtist.albumCount !== 1 ? "s" : ""} in your
+                            library
+                        </p>
+                    )}
+                </div>
+            )}
+
+            {/* Content - Centered */}
+            <div className="relative z-20 min-h-screen flex items-center justify-center p-4">
+                <div className="w-full max-w-md">
+                    {/* Logo */}
+                    <div className="flex items-center justify-center mb-8">
+                        <div className="relative flex gap-3 items-center group">
+                            <div className="relative">
+                                <div className="absolute inset-0 bg-white/10 blur-xl rounded-full group-hover:bg-white/20 transition-all duration-300" />
+                                <Image
+                                    src="/assets/images/LIDIFY.webp"
+                                    alt="Lidify"
+                                    width={40}
+                                    height={40}
+                                    className="relative z-10 drop-shadow-2xl"
+                                />
+                            </div>
+                            <span className="text-3xl font-bold bg-gradient-to-r from-white via-white to-gray-200 bg-clip-text text-transparent drop-shadow-2xl">
+                                Lidify
+                            </span>
+                        </div>
+                    </div>
+
+                    {/* Content Card */}
+                    <div className="bg-[#111]/90 rounded-lg p-6 md:p-8 border border-white/10 shadow-xl">
+                        <h1 className="text-2xl font-bold text-white mb-1 text-center">
+                            {title}
+                        </h1>
+                        <p className="text-white/60 text-center mb-8">
+                            {subtitle}
+                        </p>
+
+                        {children}
+                    </div>
+
+                    {/* Footer */}
+                    <p className="text-center text-white/40 text-sm mt-6">
+                        © 2025 Lidify. Your music, your way.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/layout/AuthenticatedLayout.tsx
+++ b/frontend/components/layout/AuthenticatedLayout.tsx
@@ -19,7 +19,7 @@ import { useIsMobile, useIsTablet } from "@/hooks/useMediaQuery";
 import { useIsTV } from "@/lib/tv-utils";
 import { useActivityPanel } from "@/hooks/useActivityPanel";
 
-const publicPaths = ["/login", "/register", "/onboarding", "/sync"];
+const publicPaths = ["/login", "/login/credentials", "/register", "/onboarding", "/sync"];
 
 export function AuthenticatedLayout({ children }: { children: ReactNode }) {
     const { isAuthenticated, isLoading } = useAuth();
@@ -59,7 +59,7 @@ export function AuthenticatedLayout({ children }: { children: ReactNode }) {
         };
     }, [activityPanel]);
 
-    const isPublicPage = publicPaths.includes(pathname);
+    const isPublicPage = publicPaths.includes(pathname) || pathname.startsWith("/auth/callback/");
 
     // Show loading state only on protected pages
     if (!isPublicPage && isLoading) {

--- a/frontend/components/providers/ConditionalAudioProvider.tsx
+++ b/frontend/components/providers/ConditionalAudioProvider.tsx
@@ -17,7 +17,7 @@ export function ConditionalAudioProvider({
     const { isAuthenticated } = useAuth();
 
     // Don't load audio provider on public pages or when not authenticated
-    const publicPages = ["/login", "/register", "/onboarding", "/setup"];
+    const publicPages = ["/login", "/login/credentials", "/register", "/onboarding", "/setup"];
     const isPublicPage = publicPages.includes(pathname);
 
     if (isPublicPage || !isAuthenticated) {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -159,6 +159,7 @@ class ApiClient {
         if (typeof window !== "undefined") {
             localStorage.setItem(AUTH_TOKEN_KEY, token);
         }
+        this.tokenInitialized = true;
     }
 
     // Clear JWT token

--- a/frontend/lib/auth/oidc-client.ts
+++ b/frontend/lib/auth/oidc-client.ts
@@ -1,0 +1,159 @@
+import { UserManager, WebStorageStateStore } from 'oidc-client-ts';
+
+// Keep a minimal UserManager cache only for metadata parsing if needed
+const userManagers: Map<string, UserManager> = new Map();
+
+export const AUTH_PROVIDERS = loadAuthProviders();
+
+export interface AuthProvider {
+    id: string;
+    name: string;
+    type: string;
+    oidcIssuer?: string;
+    oidcClientId?: string;
+    // Optional discovery metadata if the backend provides it through /api/auth/providers
+    discovery?: {
+        authorization_endpoint?: string;
+        token_endpoint?: string;
+        userinfo_endpoint?: string;
+        end_session_endpoint?: string;
+        jwks_uri?: string;
+    };
+}
+
+async function loadAuthProviders(): Promise<AuthProvider[]> {
+    const response = await fetch("/api/auth/providers");
+    if (!response.ok) {
+        throw new Error("Failed to fetch auth providers");
+    }
+    const data = await response.json();
+    return data.providers || [];
+}
+
+export async function initOIDCClient(provider: AuthProvider) {
+    const existing = userManagers.get(provider.id);
+    if (existing) return existing;
+
+    if (provider.type !== "oidc" || !provider.oidcIssuer || !provider.oidcClientId) {
+        console.warn("[OIDC Client] OIDC provider not properly configured");
+        return null;
+    }
+
+    // Fetch OIDC discovery document
+    const discoveryResponse = await fetch(`${provider.oidcIssuer}/.well-known/openid-configuration`);
+    const discoveryData = await discoveryResponse.json();
+
+    // If discovery data is not present, abort — frontend should not fetch provider discovery directly (CORS)
+    if (!discoveryData || !discoveryData.authorization_endpoint) {
+        throw new Error('OIDC provider metadata not available in /api/auth/providers. Please ensure the backend returns discovery metadata for the provider to avoid CORS.');
+    }
+
+    console.log("[OIDC Client] Discovery data fetched (from providers endpoint):", {
+        hasAuthEndpoint: !!discoveryData.authorization_endpoint,
+        hasTokenEndpoint: !!discoveryData.token_endpoint
+    });
+
+    // Use provider-specific callback path to avoid needing to persist provider id across redirects
+    const redirectUri = `${window.location.origin}/auth/callback/${encodeURIComponent(provider.id)}`;
+
+    const userManager = new UserManager({
+        authority: provider.oidcIssuer,
+        client_id: provider.oidcClientId,
+        redirect_uri: redirectUri,
+        // Use Authorization Code Flow with PKCE (SPA) — manager will generate code_challenge and store code_verifier in storage
+        response_type: 'code',
+        scope: 'openid profile email',
+        // Use localStorage instead of sessionStorage so state persists across redirects
+        userStore: new WebStorageStateStore({ store: window.localStorage }),
+        metadata: {
+            issuer: provider.oidcIssuer,
+            authorization_endpoint: discoveryData.authorization_endpoint,
+            token_endpoint: discoveryData.token_endpoint,
+            userinfo_endpoint: discoveryData.userinfo_endpoint,
+            end_session_endpoint: discoveryData.end_session_endpoint,
+            jwks_uri: discoveryData.jwks_uri,
+        }
+    });
+
+    userManagers.set(provider.id, userManager);
+    return userManager;
+}
+
+// Start login by letting the client (UserManager) generate PKCE and redirect to provider
+export async function startOIDCLogin(provider: AuthProvider) {
+    const manager = await initOIDCClient(provider);
+    if (!manager) throw new Error("OIDC not configured");
+
+    // manager.signinRedirect will create PKCE code_challenge, store code_verifier locally, and redirect browser
+    await manager.signinRedirect();
+}
+
+export async function handleOIDCCallback(providerId: string): Promise<string> {
+    const providers = await AUTH_PROVIDERS;
+    const provider = providers.find(p => p.id === providerId);
+
+    if (!provider) {
+        throw new Error('OIDC provider id not found in callback URL');
+    }
+
+    if (!provider) throw new Error('No OIDC provider found');
+
+    // Parse URL for code and state
+    const urlParams = new URLSearchParams(window.location.search);
+    const code = urlParams.get('code');
+    const state = urlParams.get('state');
+    const error = urlParams.get('error');
+
+    if (error) throw new Error(`OIDC error: ${error}`);
+    if (!code) throw new Error('No authorization code received');
+
+    // Try to retrieve code_verifier from localStorage (oidc-client-ts stores state under 'oidc.' + state)
+    let codeVerifier: string | null = null;
+    if (state) {
+        const stateKey = `oidc.${state}`;
+        const stateData = localStorage.getItem(stateKey);
+        if (stateData) {
+            try {
+                const parsed = JSON.parse(stateData);
+                codeVerifier = parsed.code_verifier || null;
+            } catch (e) {
+                console.warn('[OIDC Client] Failed to parse state data:', e);
+            }
+        }
+    }
+
+    if (!codeVerifier) {
+        console.warn('[OIDC Client] No code_verifier found; PKCE may not be used in server exchange');
+    }
+
+    // Exchange authorization code for Lidify token via backend (backend will perform token exchange with provider)
+    const response = await fetch(`/api/auth/oidc/login/${encodeURIComponent(provider.id)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ providerId: provider.id, code, codeVerifier, redirectUri: `${window.location.origin}/auth/callback/${encodeURIComponent(provider.id)}`, state }),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        console.error('[OIDC Client] Token exchange failed:', errorText);
+        throw new Error(`Token exchange failed: ${response.status}`);
+    }
+
+    const { token } = await response.json();
+
+    // Clean up stored PKCE/state
+    try {
+        if (state) localStorage.removeItem(`oidc.${state}`);
+        for (let i = localStorage.length - 1; i >= 0; i--) {
+            const key = localStorage.key(i);
+            if (!key) continue;
+            if (key.startsWith('oidc.')) {
+                try { localStorage.removeItem(key); } catch (e) {}
+            }
+        }
+    } catch (e) {
+        // ignore cleanup errors
+    }
+
+    return token;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lidify-frontend",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lidify-frontend",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@tanstack/react-query": "^5.90.10",
@@ -18,6 +18,7 @@
         "howler": "^2.2.4",
         "lucide-react": "^0.552.0",
         "next": "^16.0.10",
+        "oidc-client-ts": "^3.4.1",
         "qrcode.react": "^4.2.0",
         "react": "19.2.0",
         "react-dom": "19.2.0",
@@ -81,6 +82,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1246,6 +1248,7 @@
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.57.0"
       },
@@ -1616,6 +1619,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.12.tgz",
       "integrity": "sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.12"
       },
@@ -1761,6 +1765,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1826,6 +1831,7 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -2325,6 +2331,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2665,6 +2672,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3388,6 +3396,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3573,6 +3582,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4917,6 +4927,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5618,6 +5637,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-client-ts": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.4.1.tgz",
+      "integrity": "sha512-jNdst/U28Iasukx/L5MP6b274Vr7ftQs6qAhPBCvz6Wt5rPCA+Q/tUmCzfCHHWweWw5szeMy2Gfrm1rITwUKrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5883,6 +5914,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5892,6 +5924,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5903,13 +5936,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5962,7 +5997,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6679,6 +6715,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6841,6 +6878,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7147,6 +7185,7 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "howler": "^2.2.4",
     "lucide-react": "^0.552.0",
     "next": "^16.0.10",
+    "oidc-client-ts": "^3.4.1",
     "qrcode.react": "^4.2.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",


### PR DESCRIPTION
Adds optional OIDC authentication to allow user to rely on external auth providers to access Lidify, which closes issues #33 and #19.

### Changes

- Integrated OIDC frontend support with `oidc-client-ts` and added a separate callback page.
- Added `oidcId` and `oidcUid` fields to user table to match OIDC user directly to Lidify user.
- Added an intermediary login screen with OIDC and local credentials providers that automatically redirects when only one auth source is available.
- Role mapping support for JWT claims in the OAuth token