### PR TITLE
feature: #136 Enable playlist name editing

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -668,6 +668,13 @@ class ApiClient {
         });
     }
 
+    async updatePlaylist(id: string, name: string, isPublic = false) {
+        return this.request<ApiData>(`/playlists/${id}`, {
+            method: "PUT",
+            body: JSON.stringify({ name, isPublic }),
+        });
+    }
+
     async deletePlaylist(id: string) {
         return this.request<void>(`/playlists/${id}`, {
             method: "DELETE",


### PR DESCRIPTION
## Description

Enables playlist name editing in the playlist page, as well as the Playlists page.  Updates the UI after name change.

## Type of Change

-   [ ] Bug fix (non-breaking change that fixes an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [X] Enhancement (improvement to existing functionality)
-   [ ] Documentation update
-   [ ] Code cleanup / refactoring
-   [ ] Other (please describe):

## Related Issues

Fixes #136 

## Changes Made

- Adds an edit icon to the playlist page
- Adds an edit icon to playlists page

## Testing Done

-   [X] Tested locally with Docker
-   [X] Tested specific functionality:
- Change playlist name in the playlist page
- Change playlist name in the Playlists page

## Screenshots (if applicable)
Playlist page:
<img width="1369" height="239" alt="Screenshot 2026-03-01 144624" src="https://github.com/user-attachments/assets/eaae8fbc-2cd0-42a7-a8b7-d5276c4028e7" />

Playlists page:
<img width="301" height="504" alt="Screenshot 2026-03-01 144842" src="https://github.com/user-attachments/assets/d8401bd5-9dd4-458e-903d-013b0ecafdae" />


## Checklist

-   [X] My code follows the project's code style
-   [X] I have tested my changes locally
-   [X] I have updated documentation if needed
-   [X] My changes don't introduce new warnings
-   [X] This PR targets the `main` branch
