### PR TITLE
subsonic: accept native cover ids in getCoverArt

### DIFF
--- a/backend/src/routes/subsonic/playback.ts
+++ b/backend/src/routes/subsonic/playback.ts
@@ -237,9 +237,15 @@ playbackRouter.all("/getCoverArt.view", wrap(async (req, res) => {
 
     let coverUrl: string | null = null;
 
+    // Some clients pass native cover references directly as the id value
+    // (e.g. id=native:artists/<file>.jpg).
+    if (rawId.startsWith("native:")) {
+        coverUrl = rawId;
+    }
+
     // Try album first (most common); ar- prefix skips album lookup since that ID is an artist ID.
     // Falls through to artist/track as a cascade — clients may use any prefix for any entity.
-    if (!rawId.startsWith("ar-")) {
+    if (!coverUrl && !rawId.startsWith("ar-")) {
         const album = await prisma.album.findUnique({
             where: { id },
             select: { coverUrl: true, userCoverUrl: true },


### PR DESCRIPTION
## Description

Allow image ids prefixed with "native:" in "/getCoverArt.view" handler so that artist images get displayed in Symfonium.

## Type of Change

-   [x] Bug fix (non-breaking change that fixes an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Enhancement (improvement to existing functionality)
-   [ ] Documentation update
-   [ ] Code cleanup / refactoring
-   [ ] Other (please describe):

## Related Issues


## Changes Made

- Added DB lookup bypass for IDs starting with "native:"

## Testing Done

-   [x] Tested locally with Docker
-   [x] Tested specific functionality: Symfonium compatibility

## Screenshots (if applicable)

## Checklist

-   [x] My code follows the project's code style
-   [x] I have tested my changes locally
-   [x] I have updated documentation if needed
-   [x] My changes don't introduce new warnings
-   [x] This PR targets the `main` branch
