### PR TITLE
fix(subsonic): fix search3 empty query sync, correct lyrics route and…

### DIFF
--- a/backend/src/middleware/subsonicAuth.ts
+++ b/backend/src/middleware/subsonicAuth.ts
@@ -3,6 +3,7 @@ import bcrypt from "bcrypt";
 import crypto from "crypto";
 import { prisma } from "../utils/db";
 import { subsonicError, SubsonicError } from "../utils/subsonicResponse";
+import { logger } from "../utils/logger";
 
 export async function subsonicAuth(
     req: Request,
@@ -13,8 +14,19 @@ export async function subsonicAuth(
     const apiKey = req.query.apiKey as string | undefined;
     const password = req.query.p as string | undefined;
     const tokenMd5 = req.query.t as string | undefined;
+    const requestId = res.locals.subsonicRequestId as string | undefined;
+    const authMode = tokenMd5 ? "token" : apiKey ? "apiKey" : password ? "password" : "none";
+
+    logger.debug("[SubsonicAuth] Authenticating request", {
+        requestId,
+        path: req.path,
+        username,
+        authMode,
+        userAgent: req.get("user-agent") || "unknown",
+    });
 
     if (!username) {
+        logger.debug("[SubsonicAuth] Missing username parameter", { requestId, path: req.path });
         subsonicError(req, res, SubsonicError.MISSING_PARAM, "Required parameter is missing: u");
         return;
     }
@@ -28,6 +40,7 @@ export async function subsonicAuth(
         if (tokenMd5) {
             const salt = req.query.s as string | undefined;
             if (!salt) {
+                logger.debug("[SubsonicAuth] Missing salt for token auth", { requestId, path: req.path, username });
                 subsonicError(req, res, SubsonicError.MISSING_PARAM, "Required parameter is missing: s");
                 return;
             }
@@ -38,6 +51,7 @@ export async function subsonicAuth(
             });
 
             if (!user) {
+                logger.debug("[SubsonicAuth] Unknown user during token auth", { requestId, path: req.path, username });
                 subsonicError(req, res, SubsonicError.WRONG_CREDENTIALS, "Wrong username or password");
                 return;
             }
@@ -57,6 +71,7 @@ export async function subsonicAuth(
             }
 
             if (!matchedKeyId) {
+                logger.debug("[SubsonicAuth] Token auth failed", { requestId, path: req.path, username });
                 subsonicError(req, res, SubsonicError.WRONG_CREDENTIALS, "Wrong username or password");
                 return;
             }
@@ -64,6 +79,7 @@ export async function subsonicAuth(
             prisma.apiKey.update({ where: { id: matchedKeyId }, data: { lastUsed: new Date() } }).catch(() => {});
 
             req.user = user;
+            logger.debug("[SubsonicAuth] Token auth success", { requestId, path: req.path, username, userId: user.id });
             next();
             return;
         }
@@ -78,6 +94,7 @@ export async function subsonicAuth(
             });
 
             if (!keyRecord || keyRecord.user.username !== username) {
+                logger.debug("[SubsonicAuth] API key auth failed", { requestId, path: req.path, username });
                 subsonicError(req, res, SubsonicError.WRONG_CREDENTIALS, "Wrong username or password");
                 return;
             }
@@ -88,6 +105,12 @@ export async function subsonicAuth(
                 .catch(() => {});
 
             req.user = keyRecord.user;
+            logger.debug("[SubsonicAuth] API key auth success", {
+                requestId,
+                path: req.path,
+                username,
+                userId: keyRecord.user.id,
+            });
             next();
             return;
         }
@@ -116,17 +139,26 @@ export async function subsonicAuth(
             }
 
             if (!valid || !user) {
+                logger.debug("[SubsonicAuth] Password auth failed", { requestId, path: req.path, username });
                 subsonicError(req, res, SubsonicError.WRONG_CREDENTIALS, "Wrong username or password");
                 return;
             }
 
             req.user = { id: user.id, username: user.username, role: user.role };
+            logger.debug("[SubsonicAuth] Password auth success", { requestId, path: req.path, username, userId: user.id });
             next();
             return;
         }
 
+        logger.debug("[SubsonicAuth] Missing auth credentials", { requestId, path: req.path, username });
         subsonicError(req, res, SubsonicError.MISSING_PARAM, "Required parameter is missing: p or apiKey");
     } catch (_err) {
+        logger.error("[SubsonicAuth] Authentication error", {
+            requestId,
+            path: req.path,
+            username,
+            authMode,
+        });
         subsonicError(req, res, SubsonicError.GENERIC, "Authentication error");
     }
 }

--- a/backend/src/routes/__tests__/subsonic.extensions.route.test.ts
+++ b/backend/src/routes/__tests__/subsonic.extensions.route.test.ts
@@ -1,0 +1,80 @@
+jest.mock('../../middleware/subsonicAuth', () => ({
+    subsonicAuth: (_req: any, _res: any, next: () => void) => next(),
+}));
+
+jest.mock('../../utils/db', () => ({
+    prisma: {
+        apiKey: {
+            findUnique: jest.fn(),
+            update: jest.fn(),
+        },
+    },
+}));
+
+jest.mock('../../workers/queues', () => ({
+    scanQueue: {
+        getJobCounts: jest.fn(),
+        add: jest.fn(),
+    },
+}));
+
+jest.mock('../../config', () => ({
+    config: {
+        music: { musicPath: '/music' },
+    },
+}));
+
+jest.mock('../subsonic/compat', () => ({ compatRouter: require('express').Router() }));
+jest.mock('../subsonic/library', () => ({ libraryRouter: require('express').Router() }));
+jest.mock('../subsonic/playback', () => ({ playbackRouter: require('express').Router() }));
+jest.mock('../subsonic/search', () => ({ searchRouter: require('express').Router() }));
+jest.mock('../subsonic/playlists', () => ({ playlistRouter: require('express').Router() }));
+jest.mock('../subsonic/queue', () => ({ queueRouter: require('express').Router() }));
+jest.mock('../subsonic/starred', () => ({ starredRouter: require('express').Router() }));
+jest.mock('../subsonic/artistInfo', () => ({ artistInfoRouter: require('express').Router() }));
+jest.mock('../subsonic/lyrics', () => ({ lyricsRouter: require('express').Router() }));
+jest.mock('../subsonic/userManagement', () => ({ userManagementRouter: require('express').Router() }));
+jest.mock('../subsonic/profile', () => ({ profileRouter: require('express').Router() }));
+jest.mock('../subsonic/podcasts', () => ({ podcastRouter: require('express').Router() }));
+
+import express from 'express';
+import request from 'supertest';
+import { subsonicRouter } from '../subsonic';
+
+describe('Subsonic extension advertisement', () => {
+    function makeApp() {
+        const app = express();
+        app.use('/rest', subsonicRouter);
+        return app;
+    }
+
+    it('getOpenSubsonicExtensions advertises songLyrics versions 1 and 2', async () => {
+        const app = makeApp();
+
+        const res = await request(app)
+            .get('/rest/getOpenSubsonicExtensions.view')
+            .query({ f: 'json' });
+
+        expect(res.status).toBe(200);
+        expect(res.body['subsonic-response'].status).toBe('ok');
+
+        const extensions = res.body['subsonic-response'].openSubsonicExtensions;
+        const songLyrics = extensions.find((ext: any) => ext.name === 'songLyrics');
+
+        expect(songLyrics).toBeDefined();
+        expect(songLyrics.versions).toEqual([1, 2]);
+    });
+
+    it('getOpenSubsonicExtensions emits name as XML attribute for Amperfy parser compatibility', async () => {
+        const app = makeApp();
+
+        const res = await request(app)
+            .get('/rest/getOpenSubsonicExtensions.view');
+
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toContain('text/xml');
+        // name must be an XML attribute, not a child element
+        expect(res.text).toContain('<openSubsonicExtensions name="songLyrics">');
+        expect(res.text).not.toContain('<name>songLyrics</name>');
+    });
+});

--- a/backend/src/routes/__tests__/subsonic.route.test.ts
+++ b/backend/src/routes/__tests__/subsonic.route.test.ts
@@ -267,4 +267,70 @@ describe('Subsonic lyrics routes', () => {
         );
         expect(prisma.trackLyrics.upsert).toHaveBeenCalled();
     });
+
+    it('getLyricsBySongId returns songLyrics v2 fields when enhanced=true', async () => {
+        (prisma.track.findUnique as jest.Mock).mockResolvedValue({
+            id: 'track-v2',
+            title: 'Karaoke Song',
+            duration: 120,
+            album: {
+                title: 'Karaoke Album',
+                artistId: 'artist-v2',
+                artist: { name: 'Karaoke Artist', displayName: null },
+            },
+        });
+
+        (prisma.trackLyrics.findUnique as jest.Mock).mockResolvedValue({
+            track_id: 'track-v2',
+            plain_lyrics: null,
+            synced_lyrics: '[00:01.00]Hello\n[00:03.50]World',
+            source: 'lrclib',
+        });
+
+        const res = await request(app)
+            .get('/getLyricsBySongId.view')
+            .query({ id: 'track-v2', enhanced: 'true', f: 'json' });
+
+        expect(res.status).toBe(200);
+        expect(res.body['subsonic-response'].status).toBe('ok');
+
+        const entry = res.body['subsonic-response'].lyricsList.structuredLyrics[0];
+        expect(entry.kind).toBe('main');
+        expect(entry.synced).toBe(true);
+        expect(Array.isArray(entry.cueLine)).toBe(true);
+        expect(entry.cueLine).toHaveLength(2);
+        expect(entry.cueLine[0].index).toBe(0);
+        expect(entry.cueLine[0].cue[0].byteStart).toBe(0);
+        expect(typeof entry.cueLine[0].cue[0].byteEnd).toBe('number');
+    });
+
+    it('getLyricsBySongId returns XML with structuredLyrics and line attributes for parser compatibility', async () => {
+        (prisma.track.findUnique as jest.Mock).mockResolvedValue({
+            id: 'track-xml',
+            title: 'Candy Everybody Wants',
+            duration: 200,
+            album: {
+                title: 'Our Time in Eden',
+                artistId: 'artist-xml',
+                artist: { name: '10,000 Maniacs', displayName: null },
+            },
+        });
+
+        (prisma.trackLyrics.findUnique as jest.Mock).mockResolvedValue({
+            track_id: 'track-xml',
+            plain_lyrics: null,
+            synced_lyrics: '[00:01.00]Candy\n[00:03.00]Everybody wants',
+            source: 'lrclib',
+        });
+
+        const res = await request(app)
+            .get('/getLyricsBySongId.view')
+            .query({ id: 'track-xml' });
+
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toContain('text/xml');
+        expect(res.text).toContain('<lyricsList>');
+        expect(res.text).toContain('structuredLyrics displayArtist="10,000 Maniacs" displayTitle="Candy Everybody Wants"');
+        expect(res.text).toContain('<line start="1000">Candy</line>');
+    });
 });

--- a/backend/src/routes/__tests__/subsonic.route.test.ts
+++ b/backend/src/routes/__tests__/subsonic.route.test.ts
@@ -1,0 +1,270 @@
+jest.mock('../../utils/db', () => ({
+    prisma: {
+        artist: { findMany: jest.fn() },
+        album: { findMany: jest.fn() },
+        track: { findMany: jest.fn(), findUnique: jest.fn(), findFirst: jest.fn() },
+        trackLyrics: { findUnique: jest.fn(), findFirst: jest.fn(), upsert: jest.fn() },
+    },
+}));
+
+jest.mock('../../services/search', () => ({
+    searchService: {
+        searchArtists: jest.fn(),
+        searchAlbums: jest.fn(),
+        searchTracks: jest.fn(),
+    },
+}));
+
+jest.mock('../../utils/logger', () => ({
+    logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../../services/lrclib', () => ({
+    lrclibService: {
+        fetchLyrics: jest.fn(),
+    },
+}));
+
+jest.mock('../../services/rateLimiter', () => ({
+    rateLimiter: {
+        execute: jest.fn(async (_key: string, fn: () => Promise<unknown>) => fn()),
+    },
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { prisma } from '../../utils/db';
+import { searchService } from '../../services/search';
+import { lrclibService } from '../../services/lrclib';
+import { searchRouter } from '../subsonic/search';
+import { lyricsRouter } from '../subsonic/lyrics';
+
+function makeApp() {
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+        (req as any).user = { id: 'user-1', username: 'chambers', role: 'user' };
+        res.locals.subsonicRequestId = 'test-request-id';
+        next();
+    });
+    app.use('/', searchRouter);
+    app.use('/', lyricsRouter);
+    return app;
+}
+
+describe('Subsonic search routes', () => {
+    let app: express.Application;
+
+    beforeAll(() => {
+        app = makeApp();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('search3 returns paged library data for quoted-empty query', async () => {
+        (prisma.artist.findMany as jest.Mock).mockResolvedValue([
+            {
+                id: 'artist-1',
+                name: 'Alpha Artist',
+                displayName: null,
+                heroUrl: null,
+                libraryAlbumCount: 3,
+            },
+        ]);
+
+        (prisma.album.findMany as jest.Mock).mockResolvedValue([
+            {
+                id: 'album-1',
+                title: 'Alpha Album',
+                displayTitle: null,
+                year: 2024,
+                coverUrl: null,
+                userCoverUrl: null,
+                artistId: 'artist-1',
+                _count: { tracks: 2 },
+                artist: {
+                    name: 'Alpha Artist',
+                    displayName: null,
+                    genres: ['Rock'],
+                    userGenres: [],
+                },
+            },
+        ]);
+
+        (prisma.track.findMany as jest.Mock).mockResolvedValue([
+            {
+                id: 'track-1',
+                title: 'Alpha Song',
+                trackNo: 1,
+                discNumber: null,
+                duration: 240,
+                filePath: '/music/a.flac',
+                mime: 'audio/flac',
+                fileSize: 123456,
+                album: {
+                    id: 'album-1',
+                    title: 'Alpha Album',
+                    displayTitle: null,
+                    year: 2024,
+                    artistId: 'artist-1',
+                    artist: {
+                        name: 'Alpha Artist',
+                        displayName: null,
+                        genres: ['Rock'],
+                        userGenres: [],
+                    },
+                },
+            },
+        ]);
+
+        const res = await request(app)
+            .get('/search3.view')
+            .query({
+                query: '""',
+                artistOffset: '0',
+                artistCount: '1',
+                albumOffset: '0',
+                albumCount: '1',
+                songOffset: '0',
+                songCount: '1',
+                f: 'json',
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body['subsonic-response'].status).toBe('ok');
+
+        const result = res.body['subsonic-response'].searchResult3;
+        expect(result.artist).toHaveLength(1);
+        expect(result.album).toHaveLength(1);
+        expect(result.song).toHaveLength(1);
+
+        expect(searchService.searchArtists).not.toHaveBeenCalled();
+        expect(searchService.searchAlbums).not.toHaveBeenCalled();
+        expect(searchService.searchTracks).not.toHaveBeenCalled();
+    });
+
+    it('search2 keeps empty-query behavior and returns empty result payload', async () => {
+        const res = await request(app)
+            .get('/search2.view')
+            .query({
+                query: '""',
+                artistOffset: '0',
+                artistCount: '1',
+                albumOffset: '0',
+                albumCount: '1',
+                songOffset: '0',
+                songCount: '1',
+                f: 'json',
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body['subsonic-response'].status).toBe('ok');
+        expect(res.body['subsonic-response'].searchResult).toEqual({});
+
+        expect(prisma.artist.findMany).not.toHaveBeenCalled();
+        expect(prisma.album.findMany).not.toHaveBeenCalled();
+        expect(prisma.track.findMany).not.toHaveBeenCalled();
+    });
+});
+
+describe('Subsonic lyrics routes', () => {
+    let app: express.Application;
+
+    beforeAll(() => {
+        app = makeApp();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('getLyricsBySongId falls back to same-artist same-title lyrics when direct track lyrics are missing', async () => {
+        (prisma.track.findUnique as jest.Mock).mockResolvedValue({
+            id: 'track-a',
+            title: 'Same Song',
+            duration: 200,
+            album: {
+                title: 'Same Album',
+                artistId: 'artist-1',
+                artist: { name: 'Alpha Artist', displayName: null },
+            },
+        });
+
+        (prisma.trackLyrics.findUnique as jest.Mock).mockResolvedValue(null);
+        (prisma.trackLyrics.findFirst as jest.Mock).mockResolvedValue({
+            track_id: 'track-b',
+            plain_lyrics: 'line one\nline two',
+            synced_lyrics: null,
+        });
+
+        const res = await request(app)
+            .get('/getLyricsBySongId.view')
+            .query({ id: 'track-a', f: 'json' });
+
+        expect(res.status).toBe(200);
+        expect(res.body['subsonic-response'].status).toBe('ok');
+
+        const list = res.body['subsonic-response'].lyricsList;
+        expect(list.structuredLyrics).toHaveLength(1);
+        expect(list.structuredLyrics[0].displayTitle).toBe('Same Song');
+        expect(list.structuredLyrics[0].line).toEqual([
+            { value: 'line one' },
+            { value: 'line two' },
+        ]);
+
+        expect(prisma.trackLyrics.findFirst).toHaveBeenCalled();
+        expect(lrclibService.fetchLyrics).not.toHaveBeenCalled();
+    });
+
+    it('getLyricsBySongId fetches and stores lyrics from LRCLIB when db lyrics are missing', async () => {
+        (prisma.track.findUnique as jest.Mock).mockResolvedValue({
+            id: 'track-a',
+            title: 'Same Song',
+            duration: 200,
+            album: {
+                title: 'Same Album',
+                artistId: 'artist-1',
+                artist: { name: 'Alpha Artist', displayName: null },
+            },
+        });
+
+        (prisma.trackLyrics.findUnique as jest.Mock).mockResolvedValue(null);
+        (prisma.trackLyrics.findFirst as jest.Mock).mockResolvedValue(null);
+        (lrclibService.fetchLyrics as jest.Mock).mockResolvedValue({
+            id: 42,
+            plainLyrics: 'api line one\napi line two',
+            syncedLyrics: null,
+        });
+        (prisma.trackLyrics.upsert as jest.Mock).mockResolvedValue({
+            track_id: 'track-a',
+            plain_lyrics: 'api line one\napi line two',
+            synced_lyrics: null,
+            source: 'lrclib',
+        });
+
+        const res = await request(app)
+            .get('/getLyricsBySongId.view')
+            .query({ id: 'track-a', f: 'json' });
+
+        expect(res.status).toBe(200);
+        expect(res.body['subsonic-response'].status).toBe('ok');
+
+        const list = res.body['subsonic-response'].lyricsList;
+        expect(list.structuredLyrics).toHaveLength(1);
+        expect(list.structuredLyrics[0].displayTitle).toBe('Same Song');
+        expect(list.structuredLyrics[0].line).toEqual([
+            { value: 'api line one' },
+            { value: 'api line two' },
+        ]);
+
+        expect(lrclibService.fetchLyrics).toHaveBeenCalledWith(
+            'Same Song',
+            'Alpha Artist',
+            'Same Album',
+            200
+        );
+        expect(prisma.trackLyrics.upsert).toHaveBeenCalled();
+    });
+});

--- a/backend/src/routes/subsonic/index.ts
+++ b/backend/src/routes/subsonic/index.ts
@@ -1,10 +1,12 @@
 import { Router, Request, Response } from "express";
 import rateLimit from "express-rate-limit";
+import { randomUUID } from "crypto";
 import { subsonicAuth } from "../../middleware/subsonicAuth";
 import { subsonicOk, subsonicError, SubsonicError } from "../../utils/subsonicResponse";
 import { prisma } from "../../utils/db";
 import { scanQueue } from "../../workers/queues";
 import { config } from "../../config";
+import { logger } from "../../utils/logger";
 
 import { compatRouter } from "./compat";
 import { libraryRouter } from "./library";
@@ -20,6 +22,50 @@ import { profileRouter } from "./profile";
 import { podcastRouter } from "./podcasts";
 
 export const subsonicRouter = Router();
+
+const SENSITIVE_SUBSONIC_QUERY_KEYS = new Set(["p", "t", "s", "apiKey"]);
+
+function redactSubsonicQuery(query: Request["query"]) {
+    return Object.fromEntries(
+        Object.entries(query).map(([key, value]) => {
+            if (SENSITIVE_SUBSONIC_QUERY_KEYS.has(key)) {
+                return [key, "[REDACTED]"];
+            }
+            return [key, value];
+        })
+    );
+}
+
+// Debug trace for Subsonic API requests and responses.
+subsonicRouter.use((req: Request, res: Response, next) => {
+    const startedAt = Date.now();
+    const query = redactSubsonicQuery(req.query);
+    const requestId = req.get("x-request-id") || randomUUID();
+
+    res.locals.subsonicRequestId = requestId;
+    res.setHeader("x-request-id", requestId);
+
+    logger.debug(`[Subsonic] --> ${req.method} ${req.originalUrl}`, {
+        requestId,
+        path: req.path,
+        query,
+        userAgent: req.get("user-agent") || "unknown",
+        clientIp: req.ip,
+    });
+
+    res.on("finish", () => {
+        logger.debug(`[Subsonic] <-- ${req.method} ${req.path}`, {
+            requestId,
+            statusCode: res.statusCode,
+            durationMs: Date.now() - startedAt,
+            contentType: res.getHeader("content-type"),
+            userId: req.user?.id,
+            username: req.user?.username,
+        });
+    });
+
+    next();
+});
 
 // Rate limit the Subsonic API separately: auth does a DB query on every request
 const subsonicLimiter = rateLimit({

--- a/backend/src/routes/subsonic/index.ts
+++ b/backend/src/routes/subsonic/index.ts
@@ -148,10 +148,10 @@ subsonicRouter.all("/getMusicFolders.view", (req: Request, res: Response) => {
 subsonicRouter.all("/getOpenSubsonicExtensions.view", (req: Request, res: Response) => {
     subsonicOk(req, res, {
         openSubsonicExtensions: [
-            { name: "apiKeyAuthentication", versions: [1] },
-            { name: "songLyrics", versions: [1] },
-            { name: "indexBasedQueue", versions: [1] },
-            { name: "getPodcastEpisode", versions: [1] },
+            { "@_name": "apiKeyAuthentication", versions: [1] },
+            { "@_name": "songLyrics", versions: [1, 2] },
+            { "@_name": "indexBasedQueue", versions: [1] },
+            { "@_name": "getPodcastEpisode", versions: [1] },
         ],
     });
 });

--- a/backend/src/routes/subsonic/lyrics.ts
+++ b/backend/src/routes/subsonic/lyrics.ts
@@ -8,6 +8,10 @@ import { rateLimiter } from "../../services/rateLimiter";
 
 export const lyricsRouter = Router();
 
+function utf8ByteLength(value: string): number {
+    return Buffer.byteLength(value, "utf8");
+}
+
 function hasLyrics(lyrics: { plain_lyrics: string | null; synced_lyrics: string | null } | null | undefined) {
     return Boolean(lyrics && ((lyrics.plain_lyrics && lyrics.plain_lyrics.trim()) || (lyrics.synced_lyrics && lyrics.synced_lyrics.trim())));
 }
@@ -109,6 +113,7 @@ async function findFallbackLyricsByTrackMetadata(trackId: string, title: string,
 
 lyricsRouter.all("/getLyricsBySongId.view", wrap(async (req, res) => {
     const id = req.query.id as string | undefined;
+    const enhanced = String(req.query.enhanced || "false").toLowerCase() === "true";
     const requestId = res.locals.subsonicRequestId as string | undefined;
     if (!id) {
         return subsonicError(req, res, SubsonicError.MISSING_PARAM, "Required parameter is missing: id");
@@ -164,6 +169,12 @@ lyricsRouter.all("/getLyricsBySongId.view", wrap(async (req, res) => {
     const displayTitle = track.title;
 
     const structuredLyrics: Array<Record<string, unknown>> = [];
+    const pushStructured = (entry: Record<string, unknown>) => {
+        if (enhanced) {
+            entry.kind = "main";
+        }
+        structuredLyrics.push(entry);
+    };
 
     if (resolvedLyrics.synced_lyrics && resolvedLyrics.synced_lyrics.trim()) {
         const lines = resolvedLyrics.synced_lyrics
@@ -182,18 +193,46 @@ lyricsRouter.all("/getLyricsBySongId.view", wrap(async (req, res) => {
                     ? parseInt(fracRaw, 10) * 10
                     : parseInt(fracRaw.slice(0, 3), 10);
                 const start = min * 60000 + sec * 1000 + fracMs;
-                return { start, value: match[4] || "" };
+                return {
+                    "@_start": start,
+                    "#text": match[4] || "",
+                };
             })
-            .filter((line): line is { start: number; value: string } => Boolean(line));
+            .filter((line): line is { "@_start": number; "#text": string } => Boolean(line));
 
         if (lines.length > 0) {
-            structuredLyrics.push({
-                displayArtist,
-                displayTitle,
-                lang: "und",
-                synced: true,
+            const entry: Record<string, unknown> = {
+                "@_displayArtist": displayArtist,
+                "@_displayTitle": displayTitle,
+                "@_lang": "und",
+                "@_synced": true,
                 line: lines,
-            });
+            };
+
+            if (enhanced) {
+                const cueLine = lines.map((line, index) => {
+                    const nextStart = index < lines.length - 1 ? lines[index + 1]["@_start"] : undefined;
+                    const cue = {
+                        start: line["@_start"],
+                        ...(nextStart !== undefined ? { end: nextStart } : {}),
+                        value: line["#text"],
+                        byteStart: 0,
+                        byteEnd: Math.max(0, utf8ByteLength(line["#text"]) - 1),
+                    };
+
+                    return {
+                        index,
+                        start: line["@_start"],
+                        ...(nextStart !== undefined ? { end: nextStart } : {}),
+                        value: line["#text"],
+                        cue: [cue],
+                    };
+                });
+
+                entry.cueLine = cueLine;
+            }
+
+            pushStructured(entry);
         }
     }
 
@@ -202,14 +241,14 @@ lyricsRouter.all("/getLyricsBySongId.view", wrap(async (req, res) => {
             .split("\n")
             .map((line) => line.trim())
             .filter(Boolean)
-            .map((value) => ({ value }));
+            .map((value) => ({ "#text": value }));
 
         if (lines.length > 0) {
-            structuredLyrics.push({
-                displayArtist,
-                displayTitle,
-                lang: "und",
-                synced: false,
+            pushStructured({
+                "@_displayArtist": displayArtist,
+                "@_displayTitle": displayTitle,
+                "@_lang": "und",
+                "@_synced": false,
                 line: lines,
             });
         }

--- a/backend/src/routes/subsonic/lyrics.ts
+++ b/backend/src/routes/subsonic/lyrics.ts
@@ -2,11 +2,114 @@ import { Router } from "express";
 import { prisma } from "../../utils/db";
 import { subsonicOk, subsonicError, SubsonicError } from "../../utils/subsonicResponse";
 import { wrap } from "./mappers";
+import { logger } from "../../utils/logger";
+import { lrclibService } from "../../services/lrclib";
+import { rateLimiter } from "../../services/rateLimiter";
 
 export const lyricsRouter = Router();
 
+function hasLyrics(lyrics: { plain_lyrics: string | null; synced_lyrics: string | null } | null | undefined) {
+    return Boolean(lyrics && ((lyrics.plain_lyrics && lyrics.plain_lyrics.trim()) || (lyrics.synced_lyrics && lyrics.synced_lyrics.trim())));
+}
+
+async function fetchAndStoreLyricsForTrack(track: {
+    id: string;
+    title: string;
+    duration: number;
+    album: {
+        title: string;
+        artist: { name: string };
+    };
+}) {
+    const result = await rateLimiter.execute("lrclib", () =>
+        lrclibService.fetchLyrics(
+            track.title,
+            track.album.artist.name || "",
+            track.album.title || "",
+            track.duration || 0
+        )
+    );
+
+    if (!result) {
+        await prisma.trackLyrics.upsert({
+            where: { track_id: track.id },
+            create: {
+                track_id: track.id,
+                source: "none",
+            },
+            update: {
+                source: "none",
+                fetched_at: new Date(),
+            },
+        });
+
+        return null;
+    }
+
+    return prisma.trackLyrics.upsert({
+        where: { track_id: track.id },
+        create: {
+            track_id: track.id,
+            plain_lyrics: result.plainLyrics,
+            synced_lyrics: result.syncedLyrics,
+            source: "lrclib",
+            lrclib_id: result.id,
+        },
+        update: {
+            plain_lyrics: result.plainLyrics,
+            synced_lyrics: result.syncedLyrics,
+            source: "lrclib",
+            lrclib_id: result.id,
+            fetched_at: new Date(),
+        },
+    });
+}
+
+async function resolveLyricsForTrack(track: {
+    id: string;
+    title: string;
+    duration: number;
+    album: {
+        title: string;
+        artist: { name: string };
+    };
+}, existing: any) {
+    if (hasLyrics(existing)) return existing;
+
+    if (existing && existing.source === "none") {
+        const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+        if (existing.fetched_at && existing.fetched_at > thirtyDaysAgo) {
+            return null;
+        }
+    }
+
+    try {
+        return await fetchAndStoreLyricsForTrack(track);
+    } catch (error) {
+        logger.error("[SubsonicLyrics] LRCLIB fetch failed", error);
+        return existing;
+    }
+}
+
+async function findFallbackLyricsByTrackMetadata(trackId: string, title: string, artistId: string) {
+    return prisma.trackLyrics.findFirst({
+        where: {
+            track_id: { not: trackId },
+            OR: [
+                { plain_lyrics: { not: null } },
+                { synced_lyrics: { not: null } },
+            ],
+            track: {
+                title: { equals: title, mode: "insensitive" },
+                album: { artistId },
+            },
+        },
+    });
+}
+
 lyricsRouter.all("/getLyricsBySongId.view", wrap(async (req, res) => {
     const id = req.query.id as string | undefined;
+    const requestId = res.locals.subsonicRequestId as string | undefined;
     if (!id) {
         return subsonicError(req, res, SubsonicError.MISSING_PARAM, "Required parameter is missing: id");
     }
@@ -25,7 +128,35 @@ lyricsRouter.all("/getLyricsBySongId.view", wrap(async (req, res) => {
         prisma.trackLyrics.findUnique({ where: { track_id: id } }),
     ]);
 
-    if (!track || !lyrics) {
+    if (!track) {
+        logger.debug("[SubsonicLyrics] Track not found for getLyricsBySongId", { requestId, trackId: id });
+        return subsonicOk(req, res, { lyricsList: {} });
+    }
+
+    let resolvedLyrics = lyrics;
+    if (!hasLyrics(resolvedLyrics)) {
+        resolvedLyrics = await findFallbackLyricsByTrackMetadata(
+            track.id,
+            track.title,
+            track.album.artistId
+        );
+    }
+
+    if (!hasLyrics(resolvedLyrics)) {
+        resolvedLyrics = await resolveLyricsForTrack(track, lyrics);
+    }
+
+    if (!hasLyrics(resolvedLyrics)) {
+        logger.debug("[SubsonicLyrics] No lyrics found for getLyricsBySongId", {
+            requestId,
+            trackId: id,
+            title: track.title,
+            artistId: track.album.artistId,
+        });
+        return subsonicOk(req, res, { lyricsList: {} });
+    }
+
+    if (!resolvedLyrics) {
         return subsonicOk(req, res, { lyricsList: {} });
     }
 
@@ -34,8 +165,8 @@ lyricsRouter.all("/getLyricsBySongId.view", wrap(async (req, res) => {
 
     const structuredLyrics: Array<Record<string, unknown>> = [];
 
-    if (lyrics.synced_lyrics && lyrics.synced_lyrics.trim()) {
-        const lines = lyrics.synced_lyrics
+    if (resolvedLyrics.synced_lyrics && resolvedLyrics.synced_lyrics.trim()) {
+        const lines = resolvedLyrics.synced_lyrics
             .split("\n")
             .map((line) => line.trim())
             .filter(Boolean)
@@ -66,8 +197,8 @@ lyricsRouter.all("/getLyricsBySongId.view", wrap(async (req, res) => {
         }
     }
 
-    if (lyrics.plain_lyrics && lyrics.plain_lyrics.trim()) {
-        const lines = lyrics.plain_lyrics
+    if (resolvedLyrics.plain_lyrics && resolvedLyrics.plain_lyrics.trim()) {
+        const lines = resolvedLyrics.plain_lyrics
             .split("\n")
             .map((line) => line.trim())
             .filter(Boolean)
@@ -92,6 +223,7 @@ lyricsRouter.all("/getLyricsBySongId.view", wrap(async (req, res) => {
 lyricsRouter.all("/getLyrics.view", wrap(async (req, res) => {
     const title = req.query.title as string | undefined;
     const artist = req.query.artist as string | undefined;
+    const requestId = res.locals.subsonicRequestId as string | undefined;
 
     if (!title && !artist) {
         return subsonicOk(req, res, { lyrics: {} });
@@ -123,11 +255,19 @@ lyricsRouter.all("/getLyrics.view", wrap(async (req, res) => {
     });
 
     if (!track) {
+        logger.debug("[SubsonicLyrics] No track matched getLyrics query", { requestId, title, artist });
         return subsonicOk(req, res, { lyrics: {} });
     }
 
-    const lyrics = await prisma.trackLyrics.findUnique({ where: { track_id: track.id } });
-    if (!lyrics || (!lyrics.plain_lyrics && !lyrics.synced_lyrics)) {
+    const existingLyrics = await prisma.trackLyrics.findUnique({ where: { track_id: track.id } });
+    const lyrics = await resolveLyricsForTrack(track, existingLyrics);
+
+    if (!hasLyrics(lyrics)) {
+        logger.debug("[SubsonicLyrics] Matched track without lyrics for getLyrics", {
+            requestId,
+            trackId: track.id,
+            title: track.title,
+        });
         return subsonicOk(req, res, { lyrics: {} });
     }
 

--- a/backend/src/routes/subsonic/playback.ts
+++ b/backend/src/routes/subsonic/playback.ts
@@ -7,7 +7,6 @@ import { subsonicOk, subsonicError, SubsonicError } from "../../utils/subsonicRe
 import { getAudioStreamingService } from "../../services/audioStreaming";
 import { config } from "../../config";
 import { bitrateToQuality, firstArtistGenre, mapSong, wrap } from "./mappers";
-import { normalizeArtistName } from "../../utils/artistNormalization";
 
 export const playbackRouter = Router();
 
@@ -471,42 +470,3 @@ playbackRouter.all("/deleteBookmark.view", wrap(async (req, res) => {
     return subsonicOk(req, res);
 }));
 
-// ===================== LYRICS =====================
-
-playbackRouter.all("/getLyrics.view", wrap(async (req, res) => {
-    const artist = (req.query.artist as string | undefined)?.trim();
-    const title = (req.query.title as string | undefined)?.trim();
-
-    if (!artist && !title) {
-        return subsonicOk(req, res, { lyrics: {} });
-    }
-
-    const normalizedArtist = artist ? normalizeArtistName(artist) : undefined;
-
-    const track = await prisma.track.findFirst({
-        where: {
-            ...(title ? { title: { contains: title, mode: "insensitive" as const } } : {}),
-            ...(normalizedArtist ? {
-                album: {
-                    artist: { normalizedName: normalizedArtist },
-                },
-            } : {}),
-        },
-        include: { trackLyrics: true, album: { include: { artist: true } } },
-    });
-
-    if (!track?.trackLyrics) {
-        return subsonicOk(req, res, { lyrics: {} });
-    }
-
-    const lyricsText = track.trackLyrics.plain_lyrics || track.trackLyrics.synced_lyrics || undefined;
-    const result: Record<string, unknown> = {
-        "@_artist": track.album.artist.name,
-        "@_title": track.title,
-    };
-    if (lyricsText) {
-        result["#text"] = lyricsText;
-    }
-
-    return subsonicOk(req, res, { lyrics: result });
-}));

--- a/backend/src/routes/subsonic/search.ts
+++ b/backend/src/routes/subsonic/search.ts
@@ -3,14 +3,112 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../../utils/db";
 import { subsonicOk, subsonicError, SubsonicError } from "../../utils/subsonicResponse";
 import { searchService } from "../../services/search";
-import { wrap, clamp, parseIntParam, firstArtistGenre, mapSong } from "./mappers";
+import { wrap, clamp, parseIntParam, firstArtistGenre, mapArtist, mapAlbum, mapSong } from "./mappers";
 
 export const searchRouter = Router();
+
+function normalizeSearchQuery(rawQuery: string | undefined): string {
+    const query = (rawQuery ?? "").trim();
+
+    // Some clients send a literal quoted empty string (e.g. query=%22%22).
+    if (query === '""' || query === "''") {
+        return "";
+    }
+
+    return query;
+}
+
+async function getEmptySearchArtists(limit: number, offset: number) {
+    if (limit <= 0) return [];
+
+    return prisma.artist.findMany({
+        where: { libraryAlbumCount: { gt: 0 } },
+        orderBy: [{ name: "asc" }, { id: "asc" }],
+        take: limit,
+        skip: offset,
+        select: {
+            id: true,
+            name: true,
+            displayName: true,
+            heroUrl: true,
+            libraryAlbumCount: true,
+        },
+    });
+}
+
+async function getEmptySearchAlbums(limit: number, offset: number) {
+    if (limit <= 0) return [];
+
+    return prisma.album.findMany({
+        where: { location: "LIBRARY", tracks: { some: {} } },
+        orderBy: [{ title: "asc" }, { id: "asc" }],
+        take: limit,
+        skip: offset,
+        select: {
+            id: true,
+            title: true,
+            displayTitle: true,
+            year: true,
+            coverUrl: true,
+            userCoverUrl: true,
+            artistId: true,
+            _count: { select: { tracks: true } },
+            artist: {
+                select: {
+                    name: true,
+                    displayName: true,
+                    genres: true,
+                    userGenres: true,
+                },
+            },
+        },
+    });
+}
+
+async function getEmptySearchTracks(limit: number, offset: number) {
+    if (limit <= 0) return [];
+
+    return prisma.track.findMany({
+        where: {
+            corrupt: false,
+            album: { location: "LIBRARY" },
+        },
+        orderBy: [{ title: "asc" }, { id: "asc" }],
+        take: limit,
+        skip: offset,
+        select: {
+            id: true,
+            title: true,
+            trackNo: true,
+            duration: true,
+            filePath: true,
+            mime: true,
+            fileSize: true,
+            album: {
+                select: {
+                    id: true,
+                    title: true,
+                    displayTitle: true,
+                    year: true,
+                    artistId: true,
+                    artist: {
+                        select: {
+                            name: true,
+                            displayName: true,
+                            genres: true,
+                            userGenres: true,
+                        },
+                    },
+                },
+            },
+        },
+    });
+}
 
 // ===================== SEARCH =====================
 
 searchRouter.all(["/search3.view", "/search2.view", "/search.view"], wrap(async (req, res) => {
-    const query = (req.query.query as string | undefined) ?? "";
+    const query = normalizeSearchQuery(req.query.query as string | undefined);
 
     const artistCount = clamp(parseIntParam(req.query.artistCount as string | undefined, 20), 0, 500);
     const albumCount  = clamp(parseIntParam(req.query.albumCount  as string | undefined, 20), 0, 500);
@@ -23,7 +121,67 @@ searchRouter.all(["/search3.view", "/search2.view", "/search.view"], wrap(async 
     const isLegacySearch = req.path.startsWith("/search.") || req.path.startsWith("/search/") || req.path.startsWith("/search");
     const responseKey = isSearch3 ? "searchResult3" : isLegacySearch ? "searchResult" : "searchResult2";
 
-    if (!query.trim()) {
+    if (!query) {
+        if (isSearch3) {
+            const [artists, albums, tracks] = await Promise.all([
+                getEmptySearchArtists(artistCount, artistOffset),
+                getEmptySearchAlbums(albumCount, albumOffset),
+                getEmptySearchTracks(songCount, songOffset),
+            ]);
+
+            const result: Record<string, unknown> = {};
+
+            if (artists.length > 0) {
+                result.artist = artists.map((artist) => mapArtist({
+                    ...artist,
+                    albumCount: artist.libraryAlbumCount,
+                }));
+            }
+
+            if (albums.length > 0) {
+                result.album = albums.map((album) => mapAlbum(
+                    {
+                        id: album.id,
+                        title: album.title,
+                        displayTitle: album.displayTitle,
+                        year: album.year,
+                        coverUrl: album.coverUrl,
+                        userCoverUrl: album.userCoverUrl,
+                        artistId: album.artistId,
+                        songCount: album._count.tracks,
+                        genre: firstArtistGenre(album.artist.genres, album.artist.userGenres),
+                    },
+                    album.artist.displayName || album.artist.name
+                ));
+            }
+
+            if (tracks.length > 0) {
+                result.song = tracks.map((track) => mapSong(
+                    {
+                        id: track.id,
+                        title: track.title,
+                        trackNo: track.trackNo,
+                        discNumber: null,
+                        duration: track.duration,
+                        filePath: track.filePath,
+                        mime: track.mime,
+                        fileSize: track.fileSize,
+                    },
+                    {
+                        id: track.album.id,
+                        title: track.album.title,
+                        displayTitle: track.album.displayTitle,
+                        year: track.album.year,
+                    },
+                    track.album.artist.displayName || track.album.artist.name,
+                    track.album.artistId,
+                    firstArtistGenre(track.album.artist.genres, track.album.artist.userGenres)
+                ));
+            }
+
+            return subsonicOk(req, res, { [responseKey]: result });
+        }
+
         return subsonicOk(req, res, { [responseKey]: {} });
     }
 


### PR DESCRIPTION
## Description

Subsonic: add the following
- request tracing 
- search3 empty-query sync support
- lyrics v2 support
- lyrics parity with web route

## Type of Change

-   [X] Bug fix (non-breaking change that fixes an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [X] Enhancement (improvement to existing functionality)
-   [ ] Documentation update
-   [ ] Code cleanup / refactoring
-   [ ] Other (please describe):

## Related Issues

Fixes #182 

## Changes Made
- search3 implementation wasn't correct - short circuit to return if query was empty
- update Subsonic Extensions to return correct format
- lyrics route now follows web route
- add lyrics v2 support
- add subsonic request tracing 
- add subsonic route tests for search and lyrics

## Testing Done

-   [X] Tested locally with Docker
-   [X] Tested specific functionality:
-- Tested and validated with Symfonium 14.1.0 on android
-- Tested and validated with Amperfy 2.1.0 build 21 on iphone


## Screenshots (if applicable)
Amperfy (iphone)
<img width="645" height="1398" alt="Amperfy 2.1.0 b21" src="https://github.com/user-attachments/assets/e68379d3-3975-4f23-9213-eaeb1b263cfe" />
Symfonium (android)
<img width="720" height="1600" alt="Symfonium 14.1.0" src="https://github.com/user-attachments/assets/b5715970-8d9b-4cf7-b6d8-9e95c8c2d1db" />
## Checklist

-   [X] My code follows the project's code style
-   [X] I have tested my changes locally
-   [X] I have updated documentation if needed
-   [X] My changes don't introduce new warnings
-   [X] This PR targets the `main` branch
