### PR TITLE
fix(library): Correct radio sampling bias for all stations

### DIFF
--- a/backend/src/routes/__tests__/library-radio.route.test.ts
+++ b/backend/src/routes/__tests__/library-radio.route.test.ts
@@ -184,6 +184,41 @@ describe('GET /radio -- type=all', () => {
     });
 });
 
+describe('GET /radio -- type=discovery', () => {
+    let app: express.Application;
+
+    beforeAll(() => {
+        app = makeApp();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('uses randomized SQL selection for discovery candidates from full library', async () => {
+        const discoveryIds = [{ id: 'discovery-1' }, { id: 'discovery-2' }, { id: 'discovery-3' }, { id: 'discovery-4' }];
+
+        // First discovery query returns enough unplayed tracks, so fallback query is not used.
+        (prisma.$queryRaw as jest.Mock).mockResolvedValueOnce(discoveryIds);
+        (prisma.track.findMany as jest.Mock).mockResolvedValue(discoveryIds.map((t) => makeTrack(t.id)));
+
+        const res = await request(app).get('/radio?type=discovery&limit=2');
+
+        expect(res.status).toBe(200);
+        expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+        expect(prisma.track.findMany).toHaveBeenCalledTimes(1);
+
+        const queryCallArgs = (prisma.$queryRaw as jest.Mock).mock.calls[0];
+        const queryTemplate = String(queryCallArgs[0]);
+        expect(queryTemplate).toContain('HAVING COUNT(p.id) = 0');
+        expect(queryTemplate).toContain('ORDER BY RANDOM()');
+
+        const hydrateCallArgs = (prisma.track.findMany as jest.Mock).mock.calls[0][0];
+        expect(hydrateCallArgs.where.id.in).toHaveLength(2);
+        expect(hydrateCallArgs.where.id.in.every((id: string) => discoveryIds.some((t) => t.id === id))).toBe(true);
+    });
+});
+
 describe('GET /radio -- type=genre', () => {
     let app: express.Application;
 
@@ -252,5 +287,40 @@ describe('GET /radio -- type=decade', () => {
 
         const returnedIds = res.body.tracks.map((t: { id: string }) => t.id);
         expect(returnedIds).toEqual(expect.arrayContaining(decadeIds.map((t) => t.id)));
+    });
+});
+
+describe('GET /radio -- type=workout', () => {
+    let app: express.Application;
+
+    beforeAll(() => {
+        app = makeApp();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('uses randomized SQL selection for workout candidates from full library', async () => {
+        const workoutIds = [{ id: 'workout-1' }, { id: 'workout-2' }, { id: 'workout-3' }, { id: 'workout-4' }];
+
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue(workoutIds);
+        (prisma.track.findMany as jest.Mock).mockResolvedValue(workoutIds.map((t) => makeTrack(t.id)));
+
+        const res = await request(app).get('/radio?type=workout&limit=2');
+
+        expect(res.status).toBe(200);
+        expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+        expect(prisma.track.findMany).toHaveBeenCalledTimes(1);
+
+        const queryCallArgs = (prisma.$queryRaw as jest.Mock).mock.calls[0];
+        const queryTemplate = String(queryCallArgs[0]);
+        expect(queryTemplate).toContain('ORDER BY RANDOM()');
+        expect(queryTemplate).toContain('analysisStatus');
+        expect(queryTemplate).toContain('moodTags');
+
+        const hydrateCallArgs = (prisma.track.findMany as jest.Mock).mock.calls[0][0];
+        expect(hydrateCallArgs.where.id.in).toHaveLength(2);
+        expect(hydrateCallArgs.where.id.in.every((id: string) => workoutIds.some((t) => t.id === id))).toBe(true);
     });
 });

--- a/backend/src/routes/__tests__/library-radio.route.test.ts
+++ b/backend/src/routes/__tests__/library-radio.route.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Library Radio Route Integration Tests
+ *
+ * Focused regression coverage for GET /radio with type=all:
+ * ensures track IDs are sourced from randomized full-library selection,
+ * not a deterministic first-page findMany/take pattern.
+ */
+
+jest.mock('../../utils/db', () => ({
+    Prisma: {
+        SortOrder: { asc: 'asc', desc: 'desc' },
+    },
+    prisma: {
+        track: {
+            count: jest.fn(),
+            findMany: jest.fn(),
+            findUnique: jest.fn(),
+        },
+        album: {
+            findMany: jest.fn(),
+            count: jest.fn(),
+            findUnique: jest.fn(),
+            findFirst: jest.fn(),
+        },
+        play: {
+            findMany: jest.fn(),
+        },
+        audiobookProgress: {
+            findMany: jest.fn(),
+        },
+        podcastProgress: {
+            findMany: jest.fn(),
+        },
+        ownedAlbum: {
+            findMany: jest.fn(),
+            groupBy: jest.fn(),
+        },
+        trackLyrics: {
+            findUnique: jest.fn(),
+            upsert: jest.fn(),
+        },
+        genre: {
+            findMany: jest.fn(),
+        },
+        similarArtist: {
+            findMany: jest.fn(),
+        },
+        artist: {
+            findUnique: jest.fn(),
+            findMany: jest.fn(),
+        },
+        $queryRaw: jest.fn(),
+    },
+}));
+
+jest.mock('../../utils/logger', () => ({
+    logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../../services/lrclib', () => ({
+    lrclibService: {
+        fetchAndStoreLyrics: jest.fn(),
+    },
+}));
+
+jest.mock('../../services/rateLimiter', () => ({
+    rateLimiter: {
+        checkLimit: jest.fn().mockResolvedValue({ allowed: true }),
+    },
+}));
+
+jest.mock('../../utils/metadataOverrides', () => ({
+    getMergedGenres: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('../../utils/dateFilters', () => ({
+    getEffectiveYear: jest.fn(),
+    getDecadeWhereClause: jest.fn().mockReturnValue({}),
+    getDecadeFromYear: jest.fn(),
+}));
+
+jest.mock('../../config', () => ({
+    config: {
+        music: {
+            musicPath: '/music',
+        },
+    },
+}));
+
+import express from 'express';
+import request from 'supertest';
+import tracksRoutes from '../../routes/library/tracks';
+import { prisma } from '../../utils/db';
+
+function makeApp() {
+    const app = express();
+    app.use(express.json());
+    app.use('/', tracksRoutes);
+    return app;
+}
+
+function makeTrack(id: string) {
+    return {
+        id,
+        title: `Track ${id}`,
+        duration: 180,
+        trackNo: 1,
+        filePath: `/music/${id}.mp3`,
+        bpm: null,
+        energy: null,
+        valence: null,
+        arousal: null,
+        danceability: null,
+        keyScale: null,
+        instrumentalness: null,
+        analysisMode: null,
+        moodHappy: null,
+        moodSad: null,
+        moodRelaxed: null,
+        moodAggressive: null,
+        moodParty: null,
+        moodAcoustic: null,
+        moodElectronic: null,
+        album: {
+            id: `album-${id}`,
+            title: `Album ${id}`,
+            coverUrl: null,
+            artist: {
+                id: `artist-${id}`,
+                name: `Artist ${id}`,
+            },
+        },
+        trackGenres: [],
+    };
+}
+
+describe('GET /radio -- type=all', () => {
+    let app: express.Application;
+
+    beforeAll(() => {
+        app = makeApp();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('uses randomized id selection and returns only sampled tracks', async () => {
+        const sampledIds = [{ id: 'late-901' }, { id: 'late-902' }, { id: 'late-903' }];
+
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue(sampledIds);
+        (prisma.track.findMany as jest.Mock).mockResolvedValue(sampledIds.map((t) => makeTrack(t.id)));
+
+        const res = await request(app).get('/radio?type=all&limit=3');
+
+        expect(res.status).toBe(200);
+        expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+        expect(prisma.track.findMany).toHaveBeenCalledTimes(1);
+
+        const findManyArgs = (prisma.track.findMany as jest.Mock).mock.calls[0][0];
+        expect(findManyArgs.where.id.in).toEqual(expect.arrayContaining(sampledIds.map((t) => t.id)));
+
+        const returnedIds = res.body.tracks.map((t: { id: string }) => t.id);
+        expect(returnedIds).toHaveLength(3);
+        expect(returnedIds).toEqual(expect.arrayContaining(sampledIds.map((t) => t.id)));
+    });
+
+    it('does not use deterministic first-page findMany id prefetch for type=all', async () => {
+        const sampledIds = [{ id: 'library-77' }, { id: 'library-88' }];
+
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue(sampledIds);
+        (prisma.track.findMany as jest.Mock).mockResolvedValue(sampledIds.map((t) => makeTrack(t.id)));
+
+        const res = await request(app).get('/radio?type=all&limit=2');
+
+        expect(res.status).toBe(200);
+
+        const anyLegacyPrefetchCall = (prisma.track.findMany as jest.Mock).mock.calls.some((call) => {
+            const arg = call[0] || {};
+            return arg.select?.id === true && arg.take === 300 && arg.where === undefined;
+        });
+
+        expect(anyLegacyPrefetchCall).toBe(false);
+    });
+});
+
+describe('GET /radio -- type=genre', () => {
+    let app: express.Application;
+
+    beforeAll(() => {
+        app = makeApp();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('uses randomized SQL candidate selection and returns sampled genre tracks', async () => {
+        const genreIds = [{ id: 'genre-1' }, { id: 'genre-2' }];
+
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue(genreIds);
+        (prisma.track.findMany as jest.Mock).mockResolvedValue(genreIds.map((t) => makeTrack(t.id)));
+
+        const res = await request(app).get('/radio?type=genre&value=rock&limit=2');
+
+        expect(res.status).toBe(200);
+        expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+        expect(prisma.track.findMany).toHaveBeenCalledTimes(1);
+
+        const queryCallArgs = (prisma.$queryRaw as jest.Mock).mock.calls[0];
+        const queryTemplate = String(queryCallArgs[0]);
+        expect(queryTemplate).toContain('ORDER BY RANDOM()');
+        expect(queryCallArgs).toEqual(expect.arrayContaining(['%rock%', 4]));
+
+        const findManyArgs = (prisma.track.findMany as jest.Mock).mock.calls[0][0];
+        expect(findManyArgs.where.id.in).toEqual(expect.arrayContaining(genreIds.map((t) => t.id)));
+
+        const returnedIds = res.body.tracks.map((t: { id: string }) => t.id);
+        expect(returnedIds).toEqual(expect.arrayContaining(genreIds.map((t) => t.id)));
+    });
+});
+
+describe('GET /radio -- type=decade', () => {
+    let app: express.Application;
+
+    beforeAll(() => {
+        app = makeApp();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('uses randomized SQL candidate selection and returns sampled decade tracks', async () => {
+        const decadeIds = [{ id: 'decade-1' }, { id: 'decade-2' }, { id: 'decade-3' }];
+
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue(decadeIds);
+        (prisma.track.findMany as jest.Mock).mockResolvedValue(decadeIds.map((t) => makeTrack(t.id)));
+
+        const res = await request(app).get('/radio?type=decade&value=1990&limit=3');
+
+        expect(res.status).toBe(200);
+        expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+        expect(prisma.track.findMany).toHaveBeenCalledTimes(1);
+
+        const queryCallArgs = (prisma.$queryRaw as jest.Mock).mock.calls[0];
+        const queryTemplate = String(queryCallArgs[0]);
+        expect(queryTemplate).toContain('ORDER BY RANDOM()');
+
+        const hydrateCallArgs = (prisma.track.findMany as jest.Mock).mock.calls[0][0];
+        expect(hydrateCallArgs.where.id.in).toEqual(expect.arrayContaining(decadeIds.map((t) => t.id)));
+
+        const returnedIds = res.body.tracks.map((t: { id: string }) => t.id);
+        expect(returnedIds).toEqual(expect.arrayContaining(decadeIds.map((t) => t.id)));
+    });
+});

--- a/backend/src/routes/library/tracks.ts
+++ b/backend/src/routes/library/tracks.ts
@@ -23,6 +23,54 @@ const MAX_LIMIT = 10000;
 
 const router = Router();
 
+async function getRandomTrackIds(
+  params: {
+    where?: Prisma.TrackWhereInput;
+    excludeIds?: string[];
+    take: number;
+  },
+): Promise<string[]> {
+  const { where, excludeIds = [], take } = params;
+
+  if (take <= 0) {
+    return [];
+  }
+
+  const effectiveWhere: Prisma.TrackWhereInput = excludeIds.length
+    ? {
+        ...(where || {}),
+        id: {
+          notIn: excludeIds,
+        },
+      }
+    : (where || {});
+
+  const total = await prisma.track.count({ where: effectiveWhere });
+  if (total === 0) {
+    return [];
+  }
+
+  if (total <= take) {
+    const all = await prisma.track.findMany({
+      where: effectiveWhere,
+      select: { id: true },
+    });
+    return shuffleArray(all.map((t) => t.id));
+  }
+
+  const maxSkip = Math.max(0, total - take);
+  const skip = Math.floor(Math.random() * (maxSkip + 1));
+
+  const sampled = await prisma.track.findMany({
+    where: effectiveWhere,
+    select: { id: true },
+    skip,
+    take,
+  });
+
+  return shuffleArray(sampled.map((t) => t.id));
+}
+
 router.get("/recently-listened", async (req, res) => {
   try {
     const { limit = "10" } = req.query;
@@ -695,16 +743,15 @@ router.get("/radio", async (req, res) => {
 
     switch (type) {
       case "discovery":
-        const unplayedTracks = await prisma.track.findMany({
+        const unplayedTracks = await getRandomTrackIds({
           where: {
             plays: { none: {} },
           },
-          select: { id: true },
           take: limitNum * 2,
         });
 
         if (unplayedTracks.length >= limitNum) {
-          trackIds = unplayedTracks.map((t) => t.id);
+          trackIds = unplayedTracks;
         } else {
           const leastPlayedTracks = await prisma.$queryRaw<{ id: string }[]>`
                         SELECT t.id
@@ -737,24 +784,28 @@ router.get("/radio", async (req, res) => {
           logger.debug(
             "[Radio:favorites] No play data found, returning random tracks",
           );
-          const randomTracks = await prisma.track.findMany({
-            select: { id: true },
+          const randomTracks = await getRandomTrackIds({
             take: limitNum * 2,
           });
-          trackIds = randomTracks.map((t) => t.id);
+          trackIds = randomTracks;
         }
         break;
 
       case "decade":
         const decadeStart = parseInt(value as string) || 2000;
 
-        const decadeTracks = await prisma.track.findMany({
-          where: {
-            album: getDecadeWhereClause(decadeStart),
-          },
-          select: { id: true },
-          take: limitNum * 3,
-        });
+        const decadeTracks = await prisma.$queryRaw<{ id: string }[]>`
+                    SELECT t.id
+                    FROM "Track" t
+                    JOIN "Album" a ON a.id = t."albumId"
+                    WHERE (
+                        (a."originalYear" >= ${decadeStart} AND a."originalYear" < ${decadeStart + 10})
+                        OR
+                        (a."originalYear" IS NULL AND a.year >= ${decadeStart} AND a.year < ${decadeStart + 10})
+                    )
+                    ORDER BY RANDOM()
+                    LIMIT ${limitNum * 3}
+                `;
         trackIds = decadeTracks.map((t) => t.id);
         break;
 
@@ -762,23 +813,27 @@ router.get("/radio", async (req, res) => {
         const genreValue = ((value as string) || "").toLowerCase();
 
         const genreTracks = await prisma.$queryRaw<{ id: string }[]>`
-                    SELECT DISTINCT t.id
-                    FROM "Artist" ar
-                    JOIN "Album" a ON a."artistId" = ar.id
-                    JOIN "Track" t ON t."albumId" = a.id
-                    WHERE (
-                        (ar.genres IS NOT NULL AND EXISTS (
-                            SELECT 1 FROM jsonb_array_elements_text(ar.genres::jsonb) AS g(genre)
-                            WHERE LOWER(g.genre) LIKE ${"%" + genreValue + "%"}
-                        ))
-                        OR
-                        (ar."userGenres" IS NOT NULL AND EXISTS (
-                            SELECT 1 FROM jsonb_array_elements_text(ar."userGenres"::jsonb) AS ug(genre)
-                            WHERE LOWER(ug.genre) LIKE ${"%" + genreValue + "%"}
-                        ))
-                    )
-                    LIMIT ${limitNum * 2}
-                `;
+              SELECT x.id
+              FROM (
+                SELECT DISTINCT t.id
+                FROM "Artist" ar
+                JOIN "Album" a ON a."artistId" = ar.id
+                JOIN "Track" t ON t."albumId" = a.id
+                WHERE (
+                  (ar.genres IS NOT NULL AND EXISTS (
+                    SELECT 1 FROM jsonb_array_elements_text(ar.genres::jsonb) AS g(genre)
+                    WHERE LOWER(g.genre) LIKE ${"%" + genreValue + "%"}
+                  ))
+                  OR
+                  (ar."userGenres" IS NOT NULL AND EXISTS (
+                    SELECT 1 FROM jsonb_array_elements_text(ar."userGenres"::jsonb) AS ug(genre)
+                    WHERE LOWER(ug.genre) LIKE ${"%" + genreValue + "%"}
+                  ))
+                )
+              ) x
+              ORDER BY RANDOM()
+              LIMIT ${limitNum * 2}
+            `;
         trackIds = genreTracks.map((t) => t.id);
 
         logger.debug(
@@ -841,18 +896,17 @@ router.get("/radio", async (req, res) => {
             };
         }
 
-        const moodTracks = await prisma.track.findMany({
+        const moodTracks = await getRandomTrackIds({
           where: moodWhere,
-          select: { id: true },
           take: limitNum * 3,
         });
-        trackIds = moodTracks.map((t) => t.id);
+        trackIds = moodTracks;
         break;
 
       case "workout":
         let workoutTrackIds: string[] = [];
 
-        const energyTracks = await prisma.track.findMany({
+        const energyTracks = await getRandomTrackIds({
           where: {
             analysisStatus: "completed",
             OR: [
@@ -866,10 +920,9 @@ router.get("/radio", async (req, res) => {
               },
             ],
           },
-          select: { id: true },
           take: limitNum * 2,
         });
-        workoutTrackIds = energyTracks.map((t) => t.id);
+        workoutTrackIds = energyTracks;
         logger.debug(
           `[Radio:workout] Found ${workoutTrackIds.length} tracks via audio analysis`,
         );
@@ -1554,14 +1607,11 @@ router.get("/radio", async (req, res) => {
         }
 
         if (vibeMatchedIds.length < limitNum) {
-          const randomTracks = await prisma.track.findMany({
-            where: {
-              id: { notIn: [sourceTrackId, ...vibeMatchedIds] },
-            },
-            select: { id: true },
+          const randomTracks = await getRandomTrackIds({
+            excludeIds: [sourceTrackId, ...vibeMatchedIds],
             take: limitNum - vibeMatchedIds.length,
           });
-          const newIds = randomTracks.map((t) => t.id);
+          const newIds = randomTracks;
           vibeMatchedIds = [...vibeMatchedIds, ...newIds];
           logger.debug(
             `[Radio:vibe] Fallback D (random): added ${newIds.length} tracks, total: ${vibeMatchedIds.length}`,
@@ -1576,10 +1626,12 @@ router.get("/radio", async (req, res) => {
 
       case "all":
       default:
-        const allTracks = await prisma.track.findMany({
-          select: { id: true },
-          take: 300,
-        });
+        const allTracks = await prisma.$queryRaw<{ id: string }[]>`
+          SELECT id
+          FROM "Track"
+          ORDER BY RANDOM()
+          LIMIT ${Math.max(300, limitNum * 3)}
+        `;
         trackIds = allTracks.map((t) => t.id);
     }
 
@@ -1754,8 +1806,8 @@ router.get("/radio", async (req, res) => {
       title: track.title,
       duration: track.duration,
       trackNo: track.trackNo,
-      discNumber: track.discNumber,
-      discSubtitle: track.discSubtitle,
+      discNumber: (track as any).discNumber,
+      discSubtitle: (track as any).discSubtitle,
       filePath: track.filePath,
       artist: {
         id: track.album.artist.id,

--- a/backend/src/routes/library/tracks.ts
+++ b/backend/src/routes/library/tracks.ts
@@ -743,22 +743,34 @@ router.get("/radio", async (req, res) => {
 
     switch (type) {
       case "discovery":
-        const unplayedTracks = await getRandomTrackIds({
-          where: {
-            plays: { none: {} },
-          },
-          take: limitNum * 2,
-        });
+        const unplayedTracks = await prisma.$queryRaw<{ id: string }[]>`
+                    SELECT t.id
+                    FROM "Track" t
+                    LEFT JOIN "Play" p ON p."trackId" = t.id
+                    GROUP BY t.id
+                    HAVING COUNT(p.id) = 0
+                    ORDER BY RANDOM()
+                    LIMIT ${limitNum * 2}
+                `;
 
         if (unplayedTracks.length >= limitNum) {
-          trackIds = unplayedTracks;
+          trackIds = unplayedTracks.map((t) => t.id);
         } else {
           const leastPlayedTracks = await prisma.$queryRaw<{ id: string }[]>`
-                        SELECT t.id
-                        FROM "Track" t
-                        LEFT JOIN "Play" p ON p."trackId" = t.id
-                        GROUP BY t.id
-                        ORDER BY COUNT(p.id) ASC
+                        WITH play_counts AS (
+                            SELECT t.id, COUNT(p.id)::int AS play_count
+                            FROM "Track" t
+                            LEFT JOIN "Play" p ON p."trackId" = t.id
+                            GROUP BY t.id
+                        ),
+                        ranked AS (
+                            SELECT id, play_count, DENSE_RANK() OVER (ORDER BY play_count ASC) AS play_rank
+                            FROM play_counts
+                        )
+                        SELECT id
+                        FROM ranked
+                        WHERE play_rank <= 10
+                        ORDER BY RANDOM()
                         LIMIT ${limitNum * 2}
                     `;
           trackIds = leastPlayedTracks.map((t) => t.id);
@@ -906,23 +918,18 @@ router.get("/radio", async (req, res) => {
       case "workout":
         let workoutTrackIds: string[] = [];
 
-        const energyTracks = await getRandomTrackIds({
-          where: {
-            analysisStatus: "completed",
-            OR: [
-              {
-                AND: [{ energy: { gte: 0.65 } }, { bpm: { gte: 115 } }],
-              },
-              {
-                moodTags: {
-                  hasSome: ["workout", "energetic", "upbeat"],
-                },
-              },
-            ],
-          },
-          take: limitNum * 2,
-        });
-        workoutTrackIds = energyTracks;
+        const energyTracks = await prisma.$queryRaw<{ id: string }[]>`
+                    SELECT t.id
+                    FROM "Track" t
+                    WHERE t."analysisStatus" = 'completed'
+                      AND (
+                        (t.energy >= 0.65 AND t.bpm >= 115)
+                        OR t."moodTags" && ARRAY['workout', 'energetic', 'upbeat']::text[]
+                      )
+                    ORDER BY RANDOM()
+                    LIMIT ${limitNum * 2}
+                `;
+        workoutTrackIds = energyTracks.map((t) => t.id);
         logger.debug(
           `[Radio:workout] Found ${workoutTrackIds.length} tracks via audio analysis`,
         );
@@ -951,24 +958,21 @@ router.get("/radio", async (req, res) => {
             "pop punk",
           ];
 
-          const workoutGenres = await prisma.genre.findMany({
-            where: {
-              name: {
-                in: workoutGenreNames,
-                mode: "insensitive",
-              },
-            },
-            include: {
-              trackGenres: {
-                select: { trackId: true },
-                take: 50,
-              },
-            },
-          });
+          const genreTrackRows = await prisma.$queryRaw<{ id: string }[]>`
+                        SELECT x.id
+                        FROM (
+                            SELECT DISTINCT tg."trackId" AS id
+                            FROM "Genre" g
+                            JOIN "TrackGenre" tg ON tg."genreId" = g.id
+                            WHERE LOWER(g.name) IN (${Prisma.join(
+                              workoutGenreNames.map((g) => g.toLowerCase()),
+                            )})
+                        ) x
+                        ORDER BY RANDOM()
+                        LIMIT ${limitNum * 2}
+                    `;
 
-          const genreTrackIds = workoutGenres.flatMap((g) =>
-            g.trackGenres.map((tg) => tg.trackId),
-          );
+          const genreTrackIds = genreTrackRows.map((r) => r.id);
           workoutTrackIds = [
             ...new Set([...workoutTrackIds, ...genreTrackIds]),
           ];
@@ -977,17 +981,21 @@ router.get("/radio", async (req, res) => {
           );
 
           if (workoutTrackIds.length < limitNum) {
-            const albumGenreTracks = await prisma.track.findMany({
-              where: {
-                album: {
-                  OR: workoutGenreNames.map((g) => ({
-                    genres: { string_contains: g },
-                  })),
-                },
-              },
-              select: { id: true },
-              take: limitNum,
-            });
+            const albumGenreTracks = await prisma.$queryRaw<{ id: string }[]>`
+                          SELECT t.id
+                          FROM "Track" t
+                          JOIN "Album" a ON a.id = t."albumId"
+                          WHERE a.genres IS NOT NULL
+                            AND LOWER(a.genres::text) LIKE ANY (
+                              ARRAY[${Prisma.join(
+                                workoutGenreNames.map((g) =>
+                                  `%${g.toLowerCase()}%`,
+                                ),
+                              )}]::text[]
+                            )
+                          ORDER BY RANDOM()
+                          LIMIT ${limitNum}
+                      `;
             workoutTrackIds = [
               ...new Set([
                 ...workoutTrackIds,


### PR DESCRIPTION
## Description

Improves library radio randomness across all stations. Tracks are now chosen from the full library.

## Type of Change

-   [X] Bug fix (non-breaking change that fixes an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Enhancement (improvement to existing functionality)
-   [ ] Documentation update
-   [ ] Code cleanup / refactoring
-   [ ] Other (please describe):

## Related Issues

Fixes #186 

## Changes Made

- tracks.ts - fixed all type radio, genre query and decade query to utilize random selection
- library-radio.route.test.ts - Regression testts

## Testing Done

-   [X] Tested locally with Docker
-   [X] Tested specific functionality:
-- Validated Radio Shuffle All, Workout, Discovery, a bunch of genres and decades

## Screenshots (if applicable)

## Checklist

-   [X] My code follows the project's code style
-   [X] I have tested my changes locally
-   [X] I have updated documentation if needed
-   [X] My changes don't introduce new warnings
-   [X] This PR targets the `main` branch
