### PR TITLE
Downscale downloaded artwork before caching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,16 @@ DATABASE_URL="postgresql://kima:kima@localhost:5433/kima"
 REDIS_URL="redis://localhost:6380"
 
 # ==============================================================================
+# Cover-art cache sizing
+# ==============================================================================
+# Downloaded artwork is downscaled before being cached on disk. The longest
+# edge is capped per type and the image is re-encoded as JPEG. Images already
+# within budget are stored untouched. Defaults shown.
+# ARTWORK_CACHE_MAX_ALBUM=1000    # album covers (square)
+# ARTWORK_CACHE_MAX_ARTIST=1920   # artist images (also used as backdrops)
+# ARTWORK_CACHE_QUALITY=85        # JPEG re-encode quality
+
+# ==============================================================================
 # REQUIRED: Path to your music library
 # ==============================================================================
 MUSIC_PATH=/path/to/your/music

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -91,6 +91,16 @@ export const config = {
         apiKey: process.env.LASTFM_API_KEY || "c1797de6bf0b7e401b623118120cd9e1",
     },
 
+    // Cover-art cache: cap the longest edge of downloaded artwork before it is
+    // written to disk, so we don't keep multi-MB originals around or ship them
+    // to the browser. Album covers are square; artist images double as
+    // backdrops, so they get a larger cap. Quality is the JPEG re-encode level.
+    artwork: {
+        maxAlbumDim: parseInt(process.env.ARTWORK_CACHE_MAX_ALBUM || "1000", 10),
+        maxArtistDim: parseInt(process.env.ARTWORK_CACHE_MAX_ARTIST || "1920", 10),
+        quality: parseInt(process.env.ARTWORK_CACHE_QUALITY || "85", 10),
+    },
+
     allowedOrigins:
         process.env.ALLOWED_ORIGINS?.split(",").map((o) => o.trim()) ||
         (process.env.NODE_ENV === "development" ? true : []),

--- a/backend/src/services/imageStorage.ts
+++ b/backend/src/services/imageStorage.ts
@@ -75,8 +75,14 @@ export async function downloadAndStoreImage(
             return null;
         }
 
-        await fs.promises.writeFile(filePath, Buffer.from(buffer));
-        logger.debug(`[ImageStorage] Saved ${type} image: ${filename}`);
+        // Downscale oversized artwork before caching so we don't keep multi-MB
+        // originals on disk and ship them to the browser.
+        const original = Buffer.from(buffer);
+        const toWrite = await downscaleForCache(original, type);
+        await fs.promises.writeFile(filePath, toWrite);
+        logger.debug(
+            `[ImageStorage] Saved ${type} image: ${filename} (${original.byteLength} -> ${toWrite.byteLength} bytes)`
+        );
 
         return `native:${subdir}/${filename}`;
     } catch (error: any) {
@@ -172,6 +178,40 @@ export async function checkLocalArtistImage(
 export function isNativePath(url: string | null | undefined): boolean {
     if (!url) return false;
     return url.startsWith("native:");
+}
+
+/**
+ * Downscale an image buffer for on-disk caching: constrain the longest edge to
+ * a per-type maximum (see config.artwork) and re-encode as JPEG. Only ever
+ * shrinks — images already within budget are returned untouched. Falls back to
+ * the original buffer on any failure so caching never breaks on a bad image.
+ */
+async function downscaleForCache(
+    buffer: Buffer,
+    type: "artist" | "album"
+): Promise<Buffer> {
+    const maxDim =
+        type === "artist"
+            ? config.artwork.maxArtistDim
+            : config.artwork.maxAlbumDim;
+    if (!maxDim || maxDim < 16) return buffer;
+
+    try {
+        const sharp = (await import("sharp")).default;
+        const metadata = await sharp(buffer).metadata();
+        const longestEdge = Math.max(metadata.width || 0, metadata.height || 0);
+
+        // Already within budget — keep the original bytes untouched.
+        if (longestEdge && longestEdge <= maxDim) return buffer;
+
+        return await sharp(buffer)
+            .resize(maxDim, maxDim, { fit: "inside", withoutEnlargement: true })
+            .jpeg({ quality: config.artwork.quality, progressive: true })
+            .toBuffer();
+    } catch (err: any) {
+        logger.warn(`[ImageStorage] Cache downscale failed: ${err.message}`);
+        return buffer;
+    }
 }
 
 /**


### PR DESCRIPTION
## Description

Artwork fetched from external providers (fanart.tv, Spotify, Cover Art Archive, etc.) was written to the cover cache at its original resolution, so artist images of 20-50 MB ended up on disk and were shipped to the browser, making library/grid views slow to paint. This downscales artwork on write to a configurable per-type maximum.

## Type of Change

-   [ ] Bug fix (non-breaking change that fixes an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [X] Enhancement (improvement to existing functionality)
-   [ ] Documentation update
-   [ ] Code cleanup / refactoring
-   [ ] Other (please describe):

## Related Issues

N/A

## Changes Made

- `backend/src/services/imageStorage.ts` - add `downscaleForCache()` (cap longest edge per type, re-encode as JPEG via the existing `sharp` dep, shrink-only, fall back to the original buffer on error) and apply it in `downloadAndStoreImage()` before writing
- `backend/src/config.ts` - add `artwork` config (`maxAlbumDim`, `maxArtistDim`, `quality`) read from env
- `.env.example` - document `ARTWORK_CACHE_MAX_ALBUM` (1000), `ARTWORK_CACHE_MAX_ARTIST` (1920), `ARTWORK_CACHE_QUALITY` (85)

## Testing Done

-   [X] Tested locally with Docker
-   [X] Tested specific functionality:
-- Oversized source images are downscaled to the configured caps and re-encoded as JPEG
-- Images already within budget are stored byte-for-byte; on-demand `?size=` resizing is unaffected
-- A corrupt/odd image falls back to storing the original and does not throw

## Screenshots (if applicable)

## Checklist

-   [X] My code follows the project's code style
-   [X] I have tested my changes locally
-   [X] I have updated documentation if needed
-   [X] My changes don't introduce new warnings
-   [X] This PR targets the `main` branch
