### PR TITLE
feat(search): FTS + trigram/phonetic fuzzy search, ranking, and typeahead

### DIFF
--- a/backend/prisma/migrations/20260605000000_add_trgm_fuzzy_search/migration.sql
+++ b/backend/prisma/migrations/20260605000000_add_trgm_fuzzy_search/migration.sql
@@ -1,0 +1,23 @@
+-- Trigram fuzzy search support.
+--
+-- The existing full-text search (searchVector + to_tsquery) has no typo
+-- tolerance: e.g. "metalica" matches nothing while "metallica" matches. This
+-- adds pg_trgm so the search service can fall back to trigram similarity when
+-- FTS returns no rows, catching typos and Unicode-punctuation variants
+-- (e.g. "blink-182" vs the stored U+2010 "blink‐182").
+--
+-- These GIN trigram indexes are additive: the existing searchVector triggers
+-- and GIN indexes are untouched, so no reindex/backfill is required. Plain
+-- CREATE INDEX (not CONCURRENTLY) is used because Prisma runs each migration
+-- in a transaction; table sizes are small enough that the brief lock is fine.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS "Artist_name_trgm_idx"
+  ON "Artist" USING GIN (name gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "Album_title_trgm_idx"
+  ON "Album" USING GIN (title gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "Track_title_trgm_idx"
+  ON "Track" USING GIN (title gin_trgm_ops);

--- a/backend/prisma/migrations/20260606000000_simple_fts_and_normalizedname_trgm/migration.sql
+++ b/backend/prisma/migrations/20260606000000_simple_fts_and_normalizedname_trgm/migration.sql
@@ -1,0 +1,75 @@
+-- Switch MUSIC search vectors from the 'english' to the 'simple' text-search config.
+--
+-- The 'english' config stems words and strips stopwords, which mangles band
+-- names made of common words: "The The" -> empty, "Yes" survives but "The"
+-- vanishes, "Was (Not Was)" loses "Was"/"Not". 'simple' lowercases and tokenises
+-- without stemming or a stopword list, so these stay searchable. We replace the
+-- trigger functions (the BEFORE INSERT/UPDATE triggers themselves are unchanged
+-- and keep pointing at the same function names) and backfill existing rows.
+--
+-- The query side (backend/src/services/search.ts searchArtists/searchAlbums/
+-- searchTracks) is switched to to_tsquery('simple', ...) in the same change so
+-- the stored vector and the query config stay consistent per table. Podcast/
+-- Episode/Audiobook vectors and queries remain on 'english' (prose-like text
+-- benefits from stemming) and are untouched here.
+--
+-- We also add a pg_trgm GIN index on Artist.normalizedName so the search
+-- service can match accent/&-folded queries: e.g. "of mice and men" against the
+-- stored "Of Mice & Men" whose normalizedName is "of mice and men".
+-- pg_trgm was already created by migration 20260605000000_add_trgm_fuzzy_search,
+-- so no CREATE EXTENSION is needed here.
+--
+-- Plain CREATE INDEX (not CONCURRENTLY) is used because Prisma runs each
+-- migration in a transaction; the table is small enough that the brief lock is
+-- fine.
+
+-- ============================================================================
+-- ARTIST SEARCH VECTOR FUNCTION (simple config)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION artist_search_vector_trigger() RETURNS trigger AS $$
+BEGIN
+  NEW."searchVector" :=
+    setweight(to_tsvector('simple', COALESCE(NEW.name, '')), 'A');
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- ALBUM SEARCH VECTOR FUNCTION (simple config)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION album_search_vector_trigger() RETURNS trigger AS $$
+BEGIN
+  NEW."searchVector" :=
+    setweight(to_tsvector('simple', COALESCE(NEW.title, '')), 'A');
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- TRACK SEARCH VECTOR FUNCTION (simple config)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION track_search_vector_trigger() RETURNS trigger AS $$
+BEGIN
+  NEW."searchVector" :=
+    setweight(to_tsvector('simple', COALESCE(NEW.title, '')), 'A');
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- BACKFILL EXISTING ROWS (simple config)
+-- ============================================================================
+UPDATE "Artist" SET "searchVector" =
+  setweight(to_tsvector('simple', COALESCE(name, '')), 'A');
+
+UPDATE "Album" SET "searchVector" =
+  setweight(to_tsvector('simple', COALESCE(title, '')), 'A');
+
+UPDATE "Track" SET "searchVector" =
+  setweight(to_tsvector('simple', COALESCE(title, '')), 'A');
+
+-- ============================================================================
+-- TRIGRAM INDEX ON Artist.normalizedName (folded fuzzy matching)
+-- ============================================================================
+CREATE INDEX IF NOT EXISTS "Artist_normalizedName_trgm_idx"
+  ON "Artist" USING GIN ("normalizedName" gin_trgm_ops);

--- a/backend/prisma/migrations/20260607000000_add_artist_aliases/migration.sql
+++ b/backend/prisma/migrations/20260607000000_add_artist_aliases/migration.sql
@@ -1,0 +1,44 @@
+-- Add MusicBrainz artist aliases to the artist full-text search vector.
+--
+-- Artists frequently have alternate names: punctuation/spacing variants
+-- ("JAY-Z" vs "Jay Z"), localized names, and stage names. We already fetch
+-- MusicBrainz aliases during artist enrichment; this stores them on the row
+-- and folds them into "searchVector" so the EXISTING full-text search arm
+-- (backend/src/services/search.ts, to_tsquery('simple', ...)) matches an
+-- artist by an alias with no query change.
+--
+-- 'simple' matches the query side (same config the query uses, no stemming /
+-- stopwords). Aliases get weight 'B' so they rank below the primary name
+-- (weight 'A'): an exact name hit always outranks an alias-only hit.
+
+-- ============================================================================
+-- COLUMN
+-- ============================================================================
+ALTER TABLE "Artist" ADD COLUMN IF NOT EXISTS "aliases" TEXT[] NOT NULL DEFAULT '{}';
+
+-- ============================================================================
+-- ARTIST SEARCH VECTOR FUNCTION (name + aliases, simple config)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION artist_search_vector_trigger() RETURNS trigger AS $$
+BEGIN
+  NEW."searchVector" :=
+    setweight(to_tsvector('simple', COALESCE(NEW.name, '')), 'A') ||
+    setweight(to_tsvector('simple', COALESCE(array_to_string(NEW.aliases, ' '), '')), 'B');
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+-- Recreate the trigger so it also fires when "aliases" changes (the previous
+-- definition only fired on "name").
+DROP TRIGGER IF EXISTS artist_search_vector_update ON "Artist";
+CREATE TRIGGER artist_search_vector_update
+  BEFORE INSERT OR UPDATE OF name, aliases ON "Artist"
+  FOR EACH ROW EXECUTE FUNCTION artist_search_vector_trigger();
+
+-- ============================================================================
+-- BACKFILL EXISTING ROWS (aliases default to '{}', so this is effectively the
+-- same vector as before until enrichment populates aliases)
+-- ============================================================================
+UPDATE "Artist" SET "searchVector" =
+  setweight(to_tsvector('simple', COALESCE(name, '')), 'A') ||
+  setweight(to_tsvector('simple', COALESCE(array_to_string(aliases, ' '), '')), 'B');

--- a/backend/prisma/migrations/20260608000000_phonetic_artist_search/migration.sql
+++ b/backend/prisma/migrations/20260608000000_phonetic_artist_search/migration.sql
@@ -1,0 +1,24 @@
+-- Phase G: Double Metaphone phonetic matching for ARTIST search (last resort).
+--
+-- This is a RARE last-resort fallback used only when both the unified FTS +
+-- trigram search and (it would otherwise reach) the LIKE fallback turn up
+-- nothing. It catches phonetic spellings that trigram similarity misses, e.g.
+-- "ke$ha" -> "Kesha", "deadmau5" -> a "deadmouse"-ish artist. Album/track
+-- phonetic matching is deliberately NOT added: it is overkill there and would
+-- add noise; artist names are the high-value case.
+--
+-- fuzzystrmatch provides dmetaphone(). dmetaphone is IMMUTABLE, so it can back
+-- a functional btree index, making the equality lookup
+--   dmetaphone(name) = dmetaphone(<query>)
+-- cheap even though it is only hit on the rare empty-result path. We use
+-- dmetaphone (not metaphone) because metaphone requires a length argument and
+-- is not directly indexable the same way.
+--
+-- Plain CREATE INDEX (not CONCURRENTLY) is used because Prisma runs each
+-- migration in a transaction; the Artist table is small enough that the brief
+-- lock is fine.
+
+CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+
+CREATE INDEX IF NOT EXISTS "Artist_name_dmetaphone_idx"
+  ON "Artist" (dmetaphone(name));

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -47,6 +47,7 @@ model Artist {
   mbid                String                   @unique
   name                String
   normalizedName      String                   @default("")
+  aliases             String[]                 @default([])
   summary             String?
   heroUrl             String?
   genres              Json?

--- a/backend/src/__mocks__/test-env.cjs
+++ b/backend/src/__mocks__/test-env.cjs
@@ -6,3 +6,5 @@ process.env.JWT_SECRET = 'test-jwt-secret-for-testing-purposes-only-32chars';
 process.env.SESSION_SECRET = 'test-session-secret-for-testing-purposes-only';
 process.env.DATABASE_URL = 'postgresql://test:test@localhost:5433/test';
 process.env.REDIS_URL = 'redis://localhost:6379';
+process.env.MUSIC_PATH = '/music';
+process.env.SETTINGS_ENCRYPTION_KEY = 'test-settings-encryption-key-for-jest-only';

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -98,6 +98,32 @@ router.get("/", async (req, res) => {
     }
 });
 
+/**
+ * GET /search/suggest?q=query&limit=8
+ * Phase H: fast typeahead for the search box. Returns a small, ranked set of
+ * artist + album suggestions (Redis-cached in the service for 60s). Empty/short
+ * (<2 char) queries return empty arrays.
+ */
+router.get("/suggest", async (req, res) => {
+    try {
+        const { q = "", limit = "8" } = req.query;
+
+        const query = (q as string).trim();
+        const parsed = parseInt(limit as string, 10);
+        const suggestLimit = Number.isNaN(parsed) ? 8 : Math.min(Math.max(parsed, 1), 10);
+
+        if (query.length < 2) {
+            return res.json({ artists: [], albums: [] });
+        }
+
+        const results = await searchService.suggest({ query, limit: suggestLimit });
+        res.json(results);
+    } catch (error) {
+        logger.error("Search suggest error:", error);
+        res.status(500).json({ error: "Suggest failed" });
+    }
+});
+
 // GET /search/genres
 router.get("/genres", async (_req, res) => {
     try {

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -2,6 +2,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 import { redisClient } from "../utils/redis";
+import { normalizeArtistName } from "../utils/artistNormalization";
 
 export function normalizeCacheQuery(query: string): string {
     return query.trim().toLowerCase().replace(/\s+/g, " ");
@@ -159,6 +160,7 @@ export class SearchService {
         }
 
         const q = query.trim();
+        const nq = normalizeArtistName(query);
         const tsquery = this.queryToTsquery(query);
 
         // Unified FTS + trigram query. The FTS arm gets a +1.0 boost so any
@@ -167,12 +169,16 @@ export class SearchService {
         // Both arms always run so a typo'd term still gets fuzzy coverage even
         // when other terms produce FTS hits. If queryToTsquery is empty
         // (punctuation-only query) we skip the FTS arm and run trigram-only.
+        // FTS uses the 'simple' config to match the searchVector (see migration
+        // 20260606000000): band names like "The The"/"Yes" stay searchable.
+        // The trigram arm also matches normalizedName so accent/&-folded
+        // queries hit (e.g. "of mice and men" -> stored "Of Mice & Men").
         const ftsArm = tsquery
             ? Prisma.sql`
               SELECT a.id, a.name, a.mbid, a."heroUrl", a.summary,
-                     ts_rank(a."searchVector", to_tsquery('english', ${tsquery})) + 1.0 AS rank
+                     ts_rank(a."searchVector", to_tsquery('simple', ${tsquery})) + 1.0 AS rank
                 FROM "Artist" a
-               WHERE a."searchVector" @@ to_tsquery('english', ${tsquery})
+               WHERE a."searchVector" @@ to_tsquery('simple', ${tsquery})
                  AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
               UNION ALL`
             : Prisma.empty;
@@ -182,9 +188,9 @@ export class SearchService {
         SELECT id, name, mbid, "heroUrl", summary, MAX(rank) AS rank FROM (
           ${ftsArm}
           SELECT a.id, a.name, a.mbid, a."heroUrl", a.summary,
-                 similarity(a.name, ${q}) AS rank
+                 GREATEST(similarity(a.name, ${q}), similarity(a."normalizedName", ${nq})) AS rank
             FROM "Artist" a
-           WHERE a.name % ${q}
+           WHERE (a.name % ${q} OR a."normalizedName" % ${nq})
              AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
         ) u
         GROUP BY id, name, mbid, "heroUrl", summary
@@ -278,15 +284,15 @@ export class SearchService {
               SELECT a.id, a.title, a."artistId", ar.name as "artistName",
                      a.year, a."coverUrl",
                      GREATEST(
-                       CASE WHEN a."searchVector" @@ to_tsquery('english', ${tsquery})
-                            THEN ts_rank(a."searchVector", to_tsquery('english', ${tsquery})) ELSE 0 END,
-                       CASE WHEN ar."searchVector" @@ to_tsquery('english', ${tsquery})
-                            THEN ts_rank(ar."searchVector", to_tsquery('english', ${tsquery})) ELSE 0 END
+                       CASE WHEN a."searchVector" @@ to_tsquery('simple', ${tsquery})
+                            THEN ts_rank(a."searchVector", to_tsquery('simple', ${tsquery})) ELSE 0 END,
+                       CASE WHEN ar."searchVector" @@ to_tsquery('simple', ${tsquery})
+                            THEN ts_rank(ar."searchVector", to_tsquery('simple', ${tsquery})) ELSE 0 END
                      ) + 1.0 AS rank
                 FROM "Album" a
                 LEFT JOIN "Artist" ar ON a."artistId" = ar.id
-               WHERE a."searchVector" @@ to_tsquery('english', ${tsquery})
-                  OR ar."searchVector" @@ to_tsquery('english', ${tsquery})
+               WHERE a."searchVector" @@ to_tsquery('simple', ${tsquery})
+                  OR ar."searchVector" @@ to_tsquery('simple', ${tsquery})
               UNION ALL`
             : Prisma.empty;
 
@@ -386,11 +392,11 @@ export class SearchService {
             ? Prisma.sql`
               SELECT t.id, t.title, t."albumId", t.duration,
                      a.title as "albumTitle", a."artistId", ar.name as "artistName",
-                     ts_rank(t."searchVector", to_tsquery('english', ${tsquery})) + 1.0 AS rank
+                     ts_rank(t."searchVector", to_tsquery('simple', ${tsquery})) + 1.0 AS rank
                 FROM "Track" t
                 LEFT JOIN "Album" a ON t."albumId" = a.id
                 LEFT JOIN "Artist" ar ON a."artistId" = ar.id
-               WHERE t."searchVector" @@ to_tsquery('english', ${tsquery})
+               WHERE t."searchVector" @@ to_tsquery('simple', ${tsquery})
               UNION ALL`
             : Prisma.empty;
 

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -811,6 +811,57 @@ export class SearchService {
         }
     }
 
+    /**
+     * Record a query that returned zero results across all types into a Redis
+     * sorted set (key `search:zeroresults`), so we get a ranked "miss list" to
+     * tune search later. Best-effort only: never throws, so logging cannot
+     * break search. Skips empty/whitespace and very short (<2 char) queries.
+     */
+    private async recordZeroResult(query: string): Promise<void> {
+        const member = normalizeCacheQuery(query);
+        if (member.length < 2) return;
+
+        const ZERORESULTS_KEY = "search:zeroresults";
+        const MAX_ENTRIES = 500;
+        const TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+        try {
+            await redisClient.zincrby(ZERORESULTS_KEY, 1, member);
+            // Keep only the top ~500 entries (highest scores), dropping the
+            // lowest-ranked overflow.
+            await redisClient.zremrangebyrank(ZERORESULTS_KEY, 0, -(MAX_ENTRIES + 1));
+            // Refresh TTL so the miss list self-expires when searches go quiet.
+            await redisClient.expire(ZERORESULTS_KEY, TTL_SECONDS);
+        } catch (err) {
+            logger.warn("[SEARCH] Redis zero-result record error:", err);
+        }
+    }
+
+    /**
+     * Return the most frequent zero-result queries, highest count first.
+     * Intended for a future admin "miss list" view.
+     */
+    async getZeroResultQueries(
+        limit = 50
+    ): Promise<Array<{ query: string; count: number }>> {
+        try {
+            const flat = await redisClient.zrevrange(
+                "search:zeroresults",
+                0,
+                limit - 1,
+                "WITHSCORES"
+            );
+            const out: Array<{ query: string; count: number }> = [];
+            for (let i = 0; i < flat.length; i += 2) {
+                out.push({ query: flat[i], count: Number(flat[i + 1]) });
+            }
+            return out;
+        } catch (err) {
+            logger.warn("[SEARCH] Redis zero-result read error:", err);
+            return [];
+        }
+    }
+
     async searchAll({
         query,
         limit = 10,
@@ -879,6 +930,19 @@ export class SearchService {
             await redisClient.setex(cacheKey, 300, JSON.stringify(results));
         } catch (err) {
             logger.warn("[SEARCH] Redis cache write error:", err);
+        }
+
+        // Record genuine DB misses (cache-miss branch only) into the ranked
+        // zero-result list to tune search later.
+        if (
+            results.artists.length === 0 &&
+            results.albums.length === 0 &&
+            results.tracks.length === 0 &&
+            results.podcasts.length === 0 &&
+            results.audiobooks.length === 0 &&
+            results.episodes.length === 0
+        ) {
+            await this.recordZeroResult(query);
         }
 
         return results;
@@ -982,6 +1046,14 @@ export class SearchService {
             await redisClient.setex(cacheKey, 120, JSON.stringify(results));
         } catch (err) {
             logger.warn("[SEARCH] Redis write error:", err);
+        }
+
+        // Record genuine DB misses (cache-miss branch only) when the requested
+        // type returned nothing.
+        if (
+            (results[type as keyof SearchResults] ?? []).length === 0
+        ) {
+            await this.recordZeroResult(query);
         }
 
         return results;

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -173,10 +173,18 @@ export class SearchService {
         // 20260606000000): band names like "The The"/"Yes" stay searchable.
         // The trigram arm also matches normalizedName so accent/&-folded
         // queries hit (e.g. "of mice and men" -> stored "Of Mice & Men").
+        // Phase C: both arms add a modest, bounded ownership boost
+        // (LEAST(0.5, ln(1 + libraryAlbumCount) * 0.1)) so that, among
+        // similarly-relevant same-name hits, the more-owned artist wins. It is
+        // log-scaled and capped at 0.5 so a huge library can't dominate
+        // relevance; it survives the MAX(rank) GROUP BY by being baked into both
+        // arms' rank. FTS still generally outranks trigram (the +1.0 boost is
+        // larger than the 0.5 cap).
         const ftsArm = tsquery
             ? Prisma.sql`
               SELECT a.id, a.name, a.mbid, a."heroUrl", a.summary,
-                     ts_rank(a."searchVector", to_tsquery('simple', ${tsquery})) + 1.0 AS rank
+                     ts_rank(a."searchVector", to_tsquery('simple', ${tsquery})) + 1.0
+                       + LEAST(0.5, ln(1 + COALESCE(a."libraryAlbumCount", 0)) * 0.1) AS rank
                 FROM "Artist" a
                WHERE a."searchVector" @@ to_tsquery('simple', ${tsquery})
                  AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
@@ -188,7 +196,8 @@ export class SearchService {
         SELECT id, name, mbid, "heroUrl", summary, MAX(rank) AS rank FROM (
           ${ftsArm}
           SELECT a.id, a.name, a.mbid, a."heroUrl", a.summary,
-                 GREATEST(similarity(a.name, ${q}), similarity(a."normalizedName", ${nq})) AS rank
+                 GREATEST(similarity(a.name, ${q}), similarity(a."normalizedName", ${nq}))
+                   + LEAST(0.5, ln(1 + COALESCE(a."libraryAlbumCount", 0)) * 0.1) AS rank
             FROM "Artist" a
            WHERE (a.name % ${q} OR a."normalizedName" % ${nq})
              AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
@@ -279,6 +288,11 @@ export class SearchService {
         // The trigram arm matches album title OR artist name. MAX(rank) dedupes
         // an album matched by several arms. Both arms always run; FTS arm is
         // skipped when tsquery is empty (punctuation-only query).
+        // Phase C: both arms add a modest, bounded ownership boost from the
+        // parent artist's libraryAlbumCount (no per-album play count exists):
+        // LEAST(0.5, ln(1 + ar.libraryAlbumCount) * 0.1), log-scaled and capped
+        // so a large library can't dominate relevance. Baked into both arms so
+        // it survives MAX(rank); the +1.0 FTS boost still tops the 0.5 cap.
         const ftsArm = tsquery
             ? Prisma.sql`
               SELECT a.id, a.title, a."artistId", ar.name as "artistName",
@@ -288,7 +302,8 @@ export class SearchService {
                             THEN ts_rank(a."searchVector", to_tsquery('simple', ${tsquery})) ELSE 0 END,
                        CASE WHEN ar."searchVector" @@ to_tsquery('simple', ${tsquery})
                             THEN ts_rank(ar."searchVector", to_tsquery('simple', ${tsquery})) ELSE 0 END
-                     ) + 1.0 AS rank
+                     ) + 1.0
+                     + LEAST(0.5, ln(1 + COALESCE(ar."libraryAlbumCount", 0)) * 0.1) AS rank
                 FROM "Album" a
                 LEFT JOIN "Artist" ar ON a."artistId" = ar.id
                WHERE a."searchVector" @@ to_tsquery('simple', ${tsquery})
@@ -305,7 +320,8 @@ export class SearchService {
                  GREATEST(
                    similarity(a.title, ${q}),
                    similarity(COALESCE(ar.name, ''), ${q})
-                 ) AS rank
+                 )
+                 + LEAST(0.5, ln(1 + COALESCE(ar."libraryAlbumCount", 0)) * 0.1) AS rank
             FROM "Album" a
             LEFT JOIN "Artist" ar ON a."artistId" = ar.id
            WHERE a.title % ${q} OR ar.name % ${q}
@@ -388,11 +404,17 @@ export class SearchService {
         // hit outranks a pure trigram hit; trigram arm matches the track title.
         // MAX(rank) dedupes a track matched by both arms. Both arms always run;
         // FTS arm skipped when tsquery is empty (punctuation-only query).
+        // Phase C: both arms add a modest, bounded ownership boost from the
+        // parent artist's libraryAlbumCount (no per-track play count exists):
+        // LEAST(0.5, ln(1 + ar.libraryAlbumCount) * 0.1), log-scaled and capped
+        // so a large library can't dominate relevance. Baked into both arms so
+        // it survives MAX(rank); the +1.0 FTS boost still tops the 0.5 cap.
         const ftsArm = tsquery
             ? Prisma.sql`
               SELECT t.id, t.title, t."albumId", t.duration,
                      a.title as "albumTitle", a."artistId", ar.name as "artistName",
-                     ts_rank(t."searchVector", to_tsquery('simple', ${tsquery})) + 1.0 AS rank
+                     ts_rank(t."searchVector", to_tsquery('simple', ${tsquery})) + 1.0
+                       + LEAST(0.5, ln(1 + COALESCE(ar."libraryAlbumCount", 0)) * 0.1) AS rank
                 FROM "Track" t
                 LEFT JOIN "Album" a ON t."albumId" = a.id
                 LEFT JOIN "Artist" ar ON a."artistId" = ar.id
@@ -406,7 +428,8 @@ export class SearchService {
           ${ftsArm}
           SELECT t.id, t.title, t."albumId", t.duration,
                  a.title as "albumTitle", a."artistId", ar.name as "artistName",
-                 similarity(t.title, ${q}) AS rank
+                 similarity(t.title, ${q})
+                   + LEAST(0.5, ln(1 + COALESCE(ar."libraryAlbumCount", 0)) * 0.1) AS rank
             FROM "Track" t
             LEFT JOIN "Album" a ON t."albumId" = a.id
             LEFT JOIN "Artist" ar ON a."artistId" = ar.id

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -1210,12 +1210,24 @@ export class SearchService {
         }
 
         // Record genuine DB misses (cache-miss branch only) when the requested
-        // type returned nothing.
-        const typedResults = results[
-            type as Exclude<keyof SearchResults, "topResult">
+        // type returned nothing. Guard on a known type: an unrecognised ?type=
+        // value runs no query above, so without this check it would falsely
+        // record a zero-result for a query that may well have hits.
+        const VALID_TYPES: ReadonlyArray<keyof SearchResults> = [
+            "artists",
+            "albums",
+            "tracks",
+            "podcasts",
+            "audiobooks",
+            "episodes",
         ];
-        if ((typedResults ?? []).length === 0) {
-            await this.recordZeroResult(query);
+        if (VALID_TYPES.includes(type as keyof SearchResults)) {
+            const typedResults = results[
+                type as Exclude<keyof SearchResults, "topResult">
+            ];
+            if ((typedResults ?? []).length === 0) {
+                await this.recordZeroResult(query);
+            }
         }
 
         return results;

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -78,6 +78,24 @@ export interface AudiobookSearchResult {
     rank: number;
 }
 
+export interface SuggestArtist {
+    id: string;
+    name: string;
+    heroUrl: string | null;
+}
+
+export interface SuggestAlbum {
+    id: string;
+    title: string;
+    artistName: string;
+    coverUrl: string | null;
+}
+
+export interface SuggestResults {
+    artists: SuggestArtist[];
+    albums: SuggestAlbum[];
+}
+
 export interface SearchByTypeOptions {
     query: string;
     type: string;
@@ -912,6 +930,68 @@ export class SearchService {
             logger.warn("[SEARCH] Redis zero-result read error:", err);
             return [];
         }
+    }
+
+    /**
+     * Phase H: lightweight typeahead/suggest for the search box.
+     *
+     * Returns a small, trimmed set of artist + album suggestions reusing the
+     * existing ranked searchArtists/searchAlbums. Briefly Redis-cached (60s)
+     * under `search:suggest:<normalizedCacheQuery>:<limit>`, mirroring the
+     * other search caches. Queries shorter than 2 chars return empty (the
+     * full search box uses a 2-char threshold too).
+     */
+    async suggest({
+        query,
+        limit = 8,
+    }: SearchOptions): Promise<SuggestResults> {
+        const empty: SuggestResults = { artists: [], albums: [] };
+
+        const q = (query || "").trim();
+        if (q.length < 2) {
+            return empty;
+        }
+
+        // Each type gets a small slice; keep it tight for a fast dropdown.
+        const perType = Math.max(1, Math.min(limit, 5));
+
+        const cacheKey = `search:suggest:${normalizeCacheQuery(q)}:${perType}`;
+        try {
+            const cached = await redisClient.get(cacheKey);
+            if (cached) {
+                logger.debug(`[SEARCH SUGGEST] Cache HIT for query: "${q}"`);
+                return JSON.parse(cached);
+            }
+        } catch (err) {
+            logger.warn("[SEARCH SUGGEST] Redis read error:", err);
+        }
+
+        const [artists, albums] = await Promise.all([
+            this.searchArtists({ query: q, limit: perType }),
+            this.searchAlbums({ query: q, limit: perType }),
+        ]);
+
+        const results: SuggestResults = {
+            artists: artists.map((a) => ({
+                id: a.id,
+                name: a.name,
+                heroUrl: a.heroUrl,
+            })),
+            albums: albums.map((a) => ({
+                id: a.id,
+                title: a.title,
+                artistName: a.artistName,
+                coverUrl: a.coverUrl,
+            })),
+        };
+
+        try {
+            await redisClient.setex(cacheKey, 60, JSON.stringify(results));
+        } catch (err) {
+            logger.warn("[SEARCH SUGGEST] Redis write error:", err);
+        }
+
+        return results;
     }
 
     async searchAll({

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -163,6 +163,17 @@ export class SearchService {
         const nq = normalizeArtistName(query);
         const tsquery = this.queryToTsquery(query);
 
+        // Phase F: trigram is noisy on very short inputs (1-2 chars) and the %
+        // operator can return huge low-quality sets. For short queries we run
+        // FTS-only (the FTS arm already does prefix matching via :*) and clamp
+        // the result cap. If there's no usable tsquery for such a short query
+        // there's nothing to FTS, so go straight to the LIKE fallback.
+        const isShort = q.length < 3;
+        if (isShort && !tsquery) {
+            return this.searchArtistsFallback({ query, limit, offset });
+        }
+        const effectiveLimit = isShort ? Math.min(limit, 10) : limit;
+
         // Unified FTS + trigram query. The FTS arm gets a +1.0 boost so any
         // full-text hit (ts_rank up to ~1.6) always outranks a pure trigram
         // hit (similarity 0..1). MAX(rank) dedupes rows matched by both arms.
@@ -187,32 +198,84 @@ export class SearchService {
                        + LEAST(0.5, ln(1 + COALESCE(a."libraryAlbumCount", 0)) * 0.1) AS rank
                 FROM "Artist" a
                WHERE a."searchVector" @@ to_tsquery('simple', ${tsquery})
-                 AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
-              UNION ALL`
+                 AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)`
             : Prisma.empty;
 
-        try {
-            const results = await prisma.$queryRaw<ArtistSearchResult[]>(Prisma.sql`
-        SELECT id, name, mbid, "heroUrl", summary, MAX(rank) AS rank FROM (
-          ${ftsArm}
+        // Phase F: skip the trigram arm entirely for short queries (FTS-only),
+        // mirroring how the FTS arm is conditionally Prisma.empty when tsquery
+        // is "". The two arms are joined by UNION ALL only when both are present.
+        const trigramArm = isShort
+            ? Prisma.empty
+            : Prisma.sql`
           SELECT a.id, a.name, a.mbid, a."heroUrl", a.summary,
                  GREATEST(similarity(a.name, ${q}), similarity(a."normalizedName", ${nq}))
                    + LEAST(0.5, ln(1 + COALESCE(a."libraryAlbumCount", 0)) * 0.1) AS rank
             FROM "Artist" a
            WHERE (a.name % ${q} OR a."normalizedName" % ${nq})
-             AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
+             AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)`;
+
+        const unionGlue =
+            tsquery && !isShort ? Prisma.sql`UNION ALL` : Prisma.empty;
+
+        try {
+            const results = await prisma.$queryRaw<ArtistSearchResult[]>(Prisma.sql`
+        SELECT id, name, mbid, "heroUrl", summary, MAX(rank) AS rank FROM (
+          ${ftsArm}
+          ${unionGlue}
+          ${trigramArm}
         ) u
         GROUP BY id, name, mbid, "heroUrl", summary
         ORDER BY rank DESC, name ASC
-        LIMIT ${limit}
+        LIMIT ${effectiveLimit}
         OFFSET ${offset}
       `);
 
             if (results.length > 0) return results;
+            // Phase G: last-resort phonetic tier (artists only), tried only when
+            // the unified query came back empty, before the LIKE fallback.
+            const phonetic = await this.searchArtistsPhonetic({
+                query,
+                limit: effectiveLimit,
+                offset,
+            });
+            if (phonetic.length > 0) return phonetic;
             return this.searchArtistsFallback({ query, limit, offset });
         } catch (error) {
             logger.error("Artist search error:", error);
             return this.searchArtistsFallback({ query, limit, offset });
+        }
+    }
+
+    /**
+     * Phase G: Double Metaphone phonetic artist match (rare last-resort).
+     *
+     * Only called from searchArtists when the unified FTS + trigram query
+     * returns zero rows, and before the LIKE fallback. Catches phonetic
+     * spellings trigram misses ("ke$ha" -> "Kesha"). Backed by the functional
+     * index Artist_name_dmetaphone_idx (see migration 20260608000000).
+     * dmetaphone of a multiword string returns the code for roughly the first
+     * token only; that's acceptable for a last-resort tier. Never throws.
+     */
+    private async searchArtistsPhonetic({
+        query,
+        limit = 20,
+        offset = 0,
+    }: SearchOptions): Promise<ArtistSearchResult[]> {
+        const q = query.trim();
+        try {
+            return await prisma.$queryRaw<ArtistSearchResult[]>(Prisma.sql`
+        SELECT a.id, a.name, a.mbid, a."heroUrl", a.summary,
+               similarity(a.name, ${q}) AS rank
+          FROM "Artist" a
+         WHERE dmetaphone(a.name) = dmetaphone(${q})
+           AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
+         ORDER BY a.name ASC
+         LIMIT ${limit}
+         OFFSET ${offset}
+      `);
+        } catch (error) {
+            logger.error("Artist phonetic search error:", error);
+            return [];
         }
     }
 
@@ -282,6 +345,17 @@ export class SearchService {
         const q = query.trim();
         const tsquery = this.queryToTsquery(query);
 
+        // Phase F: trigram is noisy on very short inputs (1-2 chars) and the %
+        // operator can return huge low-quality sets. For short queries we run
+        // FTS-only (the FTS arm already does prefix matching via :*) and clamp
+        // the result cap. With no usable tsquery for such a short query there's
+        // nothing to FTS, so go straight to the LIKE fallback.
+        const isShort = q.length < 3;
+        if (isShort && !tsquery) {
+            return this.searchAlbumsFallback({ query, limit, offset });
+        }
+        const effectiveLimit = isShort ? Math.min(limit, 10) : limit;
+
         // Unified FTS + trigram query. The FTS arm matches either the album's
         // own searchVector or the artist's searchVector (folded into the LEFT
         // JOIN via OR), each +1.0 boosted so any FTS hit outranks pure-fuzzy.
@@ -307,14 +381,15 @@ export class SearchService {
                 FROM "Album" a
                 LEFT JOIN "Artist" ar ON a."artistId" = ar.id
                WHERE a."searchVector" @@ to_tsquery('simple', ${tsquery})
-                  OR ar."searchVector" @@ to_tsquery('simple', ${tsquery})
-              UNION ALL`
+                  OR ar."searchVector" @@ to_tsquery('simple', ${tsquery})`
             : Prisma.empty;
 
-        try {
-            const results = await prisma.$queryRaw<AlbumSearchResult[]>(Prisma.sql`
-        SELECT id, title, "artistId", "artistName", year, "coverUrl", MAX(rank) AS rank FROM (
-          ${ftsArm}
+        // Phase F: skip the trigram arm entirely for short queries (FTS-only),
+        // mirroring the conditional FTS arm. UNION ALL joins them only when both
+        // arms are present.
+        const trigramArm = isShort
+            ? Prisma.empty
+            : Prisma.sql`
           SELECT a.id, a.title, a."artistId", ar.name as "artistName",
                  a.year, a."coverUrl",
                  GREATEST(
@@ -324,11 +399,21 @@ export class SearchService {
                  + LEAST(0.5, ln(1 + COALESCE(ar."libraryAlbumCount", 0)) * 0.1) AS rank
             FROM "Album" a
             LEFT JOIN "Artist" ar ON a."artistId" = ar.id
-           WHERE a.title % ${q} OR ar.name % ${q}
+           WHERE a.title % ${q} OR ar.name % ${q}`;
+
+        const unionGlue =
+            tsquery && !isShort ? Prisma.sql`UNION ALL` : Prisma.empty;
+
+        try {
+            const results = await prisma.$queryRaw<AlbumSearchResult[]>(Prisma.sql`
+        SELECT id, title, "artistId", "artistName", year, "coverUrl", MAX(rank) AS rank FROM (
+          ${ftsArm}
+          ${unionGlue}
+          ${trigramArm}
         ) u
         GROUP BY id, title, "artistId", "artistName", year, "coverUrl"
         ORDER BY rank DESC, title ASC
-        LIMIT ${limit}
+        LIMIT ${effectiveLimit}
         OFFSET ${offset}
       `);
 
@@ -400,6 +485,17 @@ export class SearchService {
         const q = query.trim();
         const tsquery = this.queryToTsquery(query);
 
+        // Phase F: trigram is noisy on very short inputs (1-2 chars) and the %
+        // operator can return huge low-quality sets. For short queries we run
+        // FTS-only (the FTS arm already does prefix matching via :*) and clamp
+        // the result cap. With no usable tsquery for such a short query there's
+        // nothing to FTS, so go straight to the LIKE fallback.
+        const isShort = q.length < 3;
+        if (isShort && !tsquery) {
+            return this.searchTracksFallback({ query, limit, offset });
+        }
+        const effectiveLimit = isShort ? Math.min(limit, 10) : limit;
+
         // Unified FTS + trigram query. FTS arm +1.0 boosted so any full-text
         // hit outranks a pure trigram hit; trigram arm matches the track title.
         // MAX(rank) dedupes a track matched by both arms. Both arms always run;
@@ -418,14 +514,15 @@ export class SearchService {
                 FROM "Track" t
                 LEFT JOIN "Album" a ON t."albumId" = a.id
                 LEFT JOIN "Artist" ar ON a."artistId" = ar.id
-               WHERE t."searchVector" @@ to_tsquery('simple', ${tsquery})
-              UNION ALL`
+               WHERE t."searchVector" @@ to_tsquery('simple', ${tsquery})`
             : Prisma.empty;
 
-        try {
-            const results = await prisma.$queryRaw<TrackSearchResult[]>(Prisma.sql`
-        SELECT id, title, "albumId", duration, "albumTitle", "artistId", "artistName", MAX(rank) AS rank FROM (
-          ${ftsArm}
+        // Phase F: skip the trigram arm entirely for short queries (FTS-only),
+        // mirroring the conditional FTS arm. UNION ALL joins them only when both
+        // arms are present.
+        const trigramArm = isShort
+            ? Prisma.empty
+            : Prisma.sql`
           SELECT t.id, t.title, t."albumId", t.duration,
                  a.title as "albumTitle", a."artistId", ar.name as "artistName",
                  similarity(t.title, ${q})
@@ -433,11 +530,21 @@ export class SearchService {
             FROM "Track" t
             LEFT JOIN "Album" a ON t."albumId" = a.id
             LEFT JOIN "Artist" ar ON a."artistId" = ar.id
-           WHERE t.title % ${q}
+           WHERE t.title % ${q}`;
+
+        const unionGlue =
+            tsquery && !isShort ? Prisma.sql`UNION ALL` : Prisma.empty;
+
+        try {
+            const results = await prisma.$queryRaw<TrackSearchResult[]>(Prisma.sql`
+        SELECT id, title, "albumId", duration, "albumTitle", "artistId", "artistName", MAX(rank) AS rank FROM (
+          ${ftsArm}
+          ${unionGlue}
+          ${trigramArm}
         ) u
         GROUP BY id, title, "albumId", duration, "albumTitle", "artistId", "artistName"
         ORDER BY rank DESC, title ASC
-        LIMIT ${limit}
+        LIMIT ${effectiveLimit}
         OFFSET ${offset}
       `);
 

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -112,6 +112,41 @@ export class SearchService {
         return terms.map((term) => `${term}:*`).join(" & ");
     }
 
+    /**
+     * Trigram (pg_trgm) fuzzy artist search. Used only when full-text search
+     * returns nothing, to tolerate typos the prefix tsquery cannot match
+     * (e.g. "metalica" -> "Metallica"). Uses the GIN trigram index on
+     * Artist.name via the `%` operator (pg_trgm.similarity_threshold).
+     */
+    private async searchArtistsTrigram({
+        query,
+        limit = 20,
+        offset = 0,
+    }: SearchOptions): Promise<ArtistSearchResult[]> {
+        const q = query.trim();
+        if (!q) return [];
+        try {
+            return await prisma.$queryRaw<ArtistSearchResult[]>`
+        SELECT
+          a.id,
+          a.name,
+          a.mbid,
+          a."heroUrl",
+          a.summary,
+          similarity(a.name, ${q}) AS rank
+        FROM "Artist" a
+        WHERE a.name % ${q}
+          AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
+        ORDER BY rank DESC, a.name ASC
+        LIMIT ${limit}
+        OFFSET ${offset}
+      `;
+        } catch (error) {
+            logger.error("Artist trigram search error:", error);
+            return [];
+        }
+    }
+
     private async searchArtistsFallback({
         query,
         limit = 20,
@@ -174,10 +209,52 @@ export class SearchService {
         OFFSET ${offset}
       `;
 
-            return results.length > 0 ? results : this.searchArtistsFallback({ query, limit, offset });
+            if (results.length > 0) return results;
+            const fuzzy = await this.searchArtistsTrigram({ query, limit, offset });
+            return fuzzy.length > 0
+                ? fuzzy
+                : this.searchArtistsFallback({ query, limit, offset });
         } catch (error) {
             logger.error("Artist search error:", error);
             return this.searchArtistsFallback({ query, limit, offset });
+        }
+    }
+
+    /**
+     * Trigram (pg_trgm) fuzzy album search (title or artist name). Used only
+     * when full-text search returns nothing. Uses the GIN trigram indexes on
+     * Album.title and Artist.name via the `%` operator.
+     */
+    private async searchAlbumsTrigram({
+        query,
+        limit = 20,
+        offset = 0,
+    }: SearchOptions): Promise<AlbumSearchResult[]> {
+        const q = query.trim();
+        if (!q) return [];
+        try {
+            return await prisma.$queryRaw<AlbumSearchResult[]>`
+        SELECT
+          a.id,
+          a.title,
+          a."artistId",
+          ar.name AS "artistName",
+          a.year,
+          a."coverUrl",
+          GREATEST(
+            similarity(a.title, ${q}),
+            similarity(COALESCE(ar.name, ''), ${q})
+          ) AS rank
+        FROM "Album" a
+        LEFT JOIN "Artist" ar ON a."artistId" = ar.id
+        WHERE a.title % ${q} OR ar.name % ${q}
+        ORDER BY rank DESC, a.title ASC
+        LIMIT ${limit}
+        OFFSET ${offset}
+      `;
+        } catch (error) {
+            logger.error("Album trigram search error:", error);
+            return [];
         }
     }
 
@@ -287,10 +364,50 @@ export class SearchService {
         OFFSET ${offset}
       `;
 
-            return results.length > 0 ? results : this.searchAlbumsFallback({ query, limit, offset });
+            if (results.length > 0) return results;
+            const fuzzy = await this.searchAlbumsTrigram({ query, limit, offset });
+            return fuzzy.length > 0
+                ? fuzzy
+                : this.searchAlbumsFallback({ query, limit, offset });
         } catch (error) {
             logger.error("Album search error:", error);
             return this.searchAlbumsFallback({ query, limit, offset });
+        }
+    }
+
+    /**
+     * Trigram (pg_trgm) fuzzy track search by title. Used only when full-text
+     * search returns nothing. Uses the GIN trigram index on Track.title.
+     */
+    private async searchTracksTrigram({
+        query,
+        limit = 20,
+        offset = 0,
+    }: SearchOptions): Promise<TrackSearchResult[]> {
+        const q = query.trim();
+        if (!q) return [];
+        try {
+            return await prisma.$queryRaw<TrackSearchResult[]>`
+        SELECT
+          t.id,
+          t.title,
+          t."albumId",
+          t.duration,
+          a.title as "albumTitle",
+          a."artistId",
+          ar.name as "artistName",
+          similarity(t.title, ${q}) AS rank
+        FROM "Track" t
+        LEFT JOIN "Album" a ON t."albumId" = a.id
+        LEFT JOIN "Artist" ar ON a."artistId" = ar.id
+        WHERE t.title % ${q}
+        ORDER BY rank DESC, t.title ASC
+        LIMIT ${limit}
+        OFFSET ${offset}
+      `;
+        } catch (error) {
+            logger.error("Track trigram search error:", error);
+            return [];
         }
     }
 
@@ -376,7 +493,11 @@ export class SearchService {
         OFFSET ${offset}
       `;
 
-            return results.length > 0 ? results : this.searchTracksFallback({ query, limit, offset });
+            if (results.length > 0) return results;
+            const fuzzy = await this.searchTracksTrigram({ query, limit, offset });
+            return fuzzy.length > 0
+                ? fuzzy
+                : this.searchTracksFallback({ query, limit, offset });
         } catch (error) {
             logger.error("Track search error:", error);
             return this.searchTracksFallback({ query, limit, offset });

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "../utils/db";
 import { logger } from "../utils/logger";
 import { redisClient } from "../utils/redis";
@@ -91,6 +92,11 @@ export interface SearchResults {
     podcasts: PodcastSearchResult[];
     audiobooks: AudiobookSearchResult[];
     episodes: EpisodeSearchResult[];
+    topResult?: {
+        type: "artist" | "album" | "track";
+        id: string;
+        rank: number;
+    };
 }
 
 export class SearchService {
@@ -110,41 +116,6 @@ export class SearchService {
         if (terms.length === 0) return "";
 
         return terms.map((term) => `${term}:*`).join(" & ");
-    }
-
-    /**
-     * Trigram (pg_trgm) fuzzy artist search. Used only when full-text search
-     * returns nothing, to tolerate typos the prefix tsquery cannot match
-     * (e.g. "metalica" -> "Metallica"). Uses the GIN trigram index on
-     * Artist.name via the `%` operator (pg_trgm.similarity_threshold).
-     */
-    private async searchArtistsTrigram({
-        query,
-        limit = 20,
-        offset = 0,
-    }: SearchOptions): Promise<ArtistSearchResult[]> {
-        const q = query.trim();
-        if (!q) return [];
-        try {
-            return await prisma.$queryRaw<ArtistSearchResult[]>`
-        SELECT
-          a.id,
-          a.name,
-          a.mbid,
-          a."heroUrl",
-          a.summary,
-          similarity(a.name, ${q}) AS rank
-        FROM "Artist" a
-        WHERE a.name % ${q}
-          AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
-        ORDER BY rank DESC, a.name ASC
-        LIMIT ${limit}
-        OFFSET ${offset}
-      `;
-        } catch (error) {
-            logger.error("Artist trigram search error:", error);
-            return [];
-        }
     }
 
     private async searchArtistsFallback({
@@ -187,74 +158,46 @@ export class SearchService {
             return [];
         }
 
+        const q = query.trim();
         const tsquery = this.queryToTsquery(query);
-        if (!tsquery) {
-            return this.searchArtistsFallback({ query, limit, offset });
-        }
+
+        // Unified FTS + trigram query. The FTS arm gets a +1.0 boost so any
+        // full-text hit (ts_rank up to ~1.6) always outranks a pure trigram
+        // hit (similarity 0..1). MAX(rank) dedupes rows matched by both arms.
+        // Both arms always run so a typo'd term still gets fuzzy coverage even
+        // when other terms produce FTS hits. If queryToTsquery is empty
+        // (punctuation-only query) we skip the FTS arm and run trigram-only.
+        const ftsArm = tsquery
+            ? Prisma.sql`
+              SELECT a.id, a.name, a.mbid, a."heroUrl", a.summary,
+                     ts_rank(a."searchVector", to_tsquery('english', ${tsquery})) + 1.0 AS rank
+                FROM "Artist" a
+               WHERE a."searchVector" @@ to_tsquery('english', ${tsquery})
+                 AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
+              UNION ALL`
+            : Prisma.empty;
 
         try {
-            const results = await prisma.$queryRaw<ArtistSearchResult[]>`
-        SELECT
-          a.id,
-          a.name,
-          a.mbid,
-          a."heroUrl",
-          a.summary,
-          ts_rank(a."searchVector", to_tsquery('english', ${tsquery})) AS rank
-        FROM "Artist" a
-        WHERE a."searchVector" @@ to_tsquery('english', ${tsquery})
-          AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
-        ORDER BY rank DESC, a.name ASC
+            const results = await prisma.$queryRaw<ArtistSearchResult[]>(Prisma.sql`
+        SELECT id, name, mbid, "heroUrl", summary, MAX(rank) AS rank FROM (
+          ${ftsArm}
+          SELECT a.id, a.name, a.mbid, a."heroUrl", a.summary,
+                 similarity(a.name, ${q}) AS rank
+            FROM "Artist" a
+           WHERE a.name % ${q}
+             AND EXISTS (SELECT 1 FROM "Album" alb WHERE alb."artistId" = a.id)
+        ) u
+        GROUP BY id, name, mbid, "heroUrl", summary
+        ORDER BY rank DESC, name ASC
         LIMIT ${limit}
         OFFSET ${offset}
-      `;
+      `);
 
             if (results.length > 0) return results;
-            const fuzzy = await this.searchArtistsTrigram({ query, limit, offset });
-            return fuzzy.length > 0
-                ? fuzzy
-                : this.searchArtistsFallback({ query, limit, offset });
+            return this.searchArtistsFallback({ query, limit, offset });
         } catch (error) {
             logger.error("Artist search error:", error);
             return this.searchArtistsFallback({ query, limit, offset });
-        }
-    }
-
-    /**
-     * Trigram (pg_trgm) fuzzy album search (title or artist name). Used only
-     * when full-text search returns nothing. Uses the GIN trigram indexes on
-     * Album.title and Artist.name via the `%` operator.
-     */
-    private async searchAlbumsTrigram({
-        query,
-        limit = 20,
-        offset = 0,
-    }: SearchOptions): Promise<AlbumSearchResult[]> {
-        const q = query.trim();
-        if (!q) return [];
-        try {
-            return await prisma.$queryRaw<AlbumSearchResult[]>`
-        SELECT
-          a.id,
-          a.title,
-          a."artistId",
-          ar.name AS "artistName",
-          a.year,
-          a."coverUrl",
-          GREATEST(
-            similarity(a.title, ${q}),
-            similarity(COALESCE(ar.name, ''), ${q})
-          ) AS rank
-        FROM "Album" a
-        LEFT JOIN "Artist" ar ON a."artistId" = ar.id
-        WHERE a.title % ${q} OR ar.name % ${q}
-        ORDER BY rank DESC, a.title ASC
-        LIMIT ${limit}
-        OFFSET ${offset}
-      `;
-        } catch (error) {
-            logger.error("Album trigram search error:", error);
-            return [];
         }
     }
 
@@ -321,93 +264,57 @@ export class SearchService {
             return [];
         }
 
+        const q = query.trim();
         const tsquery = this.queryToTsquery(query);
-        if (!tsquery) {
-            return this.searchAlbumsFallback({ query, limit, offset });
-        }
+
+        // Unified FTS + trigram query. The FTS arm matches either the album's
+        // own searchVector or the artist's searchVector (folded into the LEFT
+        // JOIN via OR), each +1.0 boosted so any FTS hit outranks pure-fuzzy.
+        // The trigram arm matches album title OR artist name. MAX(rank) dedupes
+        // an album matched by several arms. Both arms always run; FTS arm is
+        // skipped when tsquery is empty (punctuation-only query).
+        const ftsArm = tsquery
+            ? Prisma.sql`
+              SELECT a.id, a.title, a."artistId", ar.name as "artistName",
+                     a.year, a."coverUrl",
+                     GREATEST(
+                       CASE WHEN a."searchVector" @@ to_tsquery('english', ${tsquery})
+                            THEN ts_rank(a."searchVector", to_tsquery('english', ${tsquery})) ELSE 0 END,
+                       CASE WHEN ar."searchVector" @@ to_tsquery('english', ${tsquery})
+                            THEN ts_rank(ar."searchVector", to_tsquery('english', ${tsquery})) ELSE 0 END
+                     ) + 1.0 AS rank
+                FROM "Album" a
+                LEFT JOIN "Artist" ar ON a."artistId" = ar.id
+               WHERE a."searchVector" @@ to_tsquery('english', ${tsquery})
+                  OR ar."searchVector" @@ to_tsquery('english', ${tsquery})
+              UNION ALL`
+            : Prisma.empty;
 
         try {
-            const results = await prisma.$queryRaw<AlbumSearchResult[]>`
-        SELECT * FROM (
-          SELECT DISTINCT ON (id) id, title, "artistId", "artistName", year, "coverUrl", rank
-          FROM (
-            SELECT
-              a.id,
-              a.title,
-              a."artistId",
-              ar.name as "artistName",
-              a.year,
-              a."coverUrl",
-              ts_rank(a."searchVector", to_tsquery('english', ${tsquery})) AS rank
+            const results = await prisma.$queryRaw<AlbumSearchResult[]>(Prisma.sql`
+        SELECT id, title, "artistId", "artistName", year, "coverUrl", MAX(rank) AS rank FROM (
+          ${ftsArm}
+          SELECT a.id, a.title, a."artistId", ar.name as "artistName",
+                 a.year, a."coverUrl",
+                 GREATEST(
+                   similarity(a.title, ${q}),
+                   similarity(COALESCE(ar.name, ''), ${q})
+                 ) AS rank
             FROM "Album" a
             LEFT JOIN "Artist" ar ON a."artistId" = ar.id
-            WHERE a."searchVector" @@ to_tsquery('english', ${tsquery})
-
-            UNION ALL
-
-            SELECT
-              a.id,
-              a.title,
-              a."artistId",
-              ar.name as "artistName",
-              a.year,
-              a."coverUrl",
-              ts_rank(ar."searchVector", to_tsquery('english', ${tsquery})) AS rank
-            FROM "Album" a
-            INNER JOIN "Artist" ar ON a."artistId" = ar.id
-            WHERE ar."searchVector" @@ to_tsquery('english', ${tsquery})
-          ) combined
-          ORDER BY id, rank DESC
-        ) deduped
+           WHERE a.title % ${q} OR ar.name % ${q}
+        ) u
+        GROUP BY id, title, "artistId", "artistName", year, "coverUrl"
         ORDER BY rank DESC, title ASC
         LIMIT ${limit}
         OFFSET ${offset}
-      `;
+      `);
 
             if (results.length > 0) return results;
-            const fuzzy = await this.searchAlbumsTrigram({ query, limit, offset });
-            return fuzzy.length > 0
-                ? fuzzy
-                : this.searchAlbumsFallback({ query, limit, offset });
+            return this.searchAlbumsFallback({ query, limit, offset });
         } catch (error) {
             logger.error("Album search error:", error);
             return this.searchAlbumsFallback({ query, limit, offset });
-        }
-    }
-
-    /**
-     * Trigram (pg_trgm) fuzzy track search by title. Used only when full-text
-     * search returns nothing. Uses the GIN trigram index on Track.title.
-     */
-    private async searchTracksTrigram({
-        query,
-        limit = 20,
-        offset = 0,
-    }: SearchOptions): Promise<TrackSearchResult[]> {
-        const q = query.trim();
-        if (!q) return [];
-        try {
-            return await prisma.$queryRaw<TrackSearchResult[]>`
-        SELECT
-          t.id,
-          t.title,
-          t."albumId",
-          t.duration,
-          a.title as "albumTitle",
-          a."artistId",
-          ar.name as "artistName",
-          similarity(t.title, ${q}) AS rank
-        FROM "Track" t
-        LEFT JOIN "Album" a ON t."albumId" = a.id
-        LEFT JOIN "Artist" ar ON a."artistId" = ar.id
-        WHERE t.title % ${q}
-        ORDER BY rank DESC, t.title ASC
-        LIMIT ${limit}
-        OFFSET ${offset}
-      `;
-        } catch (error) {
-            logger.error("Track trigram search error:", error);
-            return [];
         }
     }
 
@@ -468,36 +375,45 @@ export class SearchService {
             return [];
         }
 
+        const q = query.trim();
         const tsquery = this.queryToTsquery(query);
-        if (!tsquery) {
-            return this.searchTracksFallback({ query, limit, offset });
-        }
+
+        // Unified FTS + trigram query. FTS arm +1.0 boosted so any full-text
+        // hit outranks a pure trigram hit; trigram arm matches the track title.
+        // MAX(rank) dedupes a track matched by both arms. Both arms always run;
+        // FTS arm skipped when tsquery is empty (punctuation-only query).
+        const ftsArm = tsquery
+            ? Prisma.sql`
+              SELECT t.id, t.title, t."albumId", t.duration,
+                     a.title as "albumTitle", a."artistId", ar.name as "artistName",
+                     ts_rank(t."searchVector", to_tsquery('english', ${tsquery})) + 1.0 AS rank
+                FROM "Track" t
+                LEFT JOIN "Album" a ON t."albumId" = a.id
+                LEFT JOIN "Artist" ar ON a."artistId" = ar.id
+               WHERE t."searchVector" @@ to_tsquery('english', ${tsquery})
+              UNION ALL`
+            : Prisma.empty;
 
         try {
-            const results = await prisma.$queryRaw<TrackSearchResult[]>`
-        SELECT
-          t.id,
-          t.title,
-          t."albumId",
-          t.duration,
-          a.title as "albumTitle",
-          a."artistId",
-          ar.name as "artistName",
-          ts_rank(t."searchVector", to_tsquery('english', ${tsquery})) AS rank
-        FROM "Track" t
-        LEFT JOIN "Album" a ON t."albumId" = a.id
-        LEFT JOIN "Artist" ar ON a."artistId" = ar.id
-        WHERE t."searchVector" @@ to_tsquery('english', ${tsquery})
-        ORDER BY rank DESC, t.title ASC
+            const results = await prisma.$queryRaw<TrackSearchResult[]>(Prisma.sql`
+        SELECT id, title, "albumId", duration, "albumTitle", "artistId", "artistName", MAX(rank) AS rank FROM (
+          ${ftsArm}
+          SELECT t.id, t.title, t."albumId", t.duration,
+                 a.title as "albumTitle", a."artistId", ar.name as "artistName",
+                 similarity(t.title, ${q}) AS rank
+            FROM "Track" t
+            LEFT JOIN "Album" a ON t."albumId" = a.id
+            LEFT JOIN "Artist" ar ON a."artistId" = ar.id
+           WHERE t.title % ${q}
+        ) u
+        GROUP BY id, title, "albumId", duration, "albumTitle", "artistId", "artistName"
+        ORDER BY rank DESC, title ASC
         LIMIT ${limit}
         OFFSET ${offset}
-      `;
+      `);
 
             if (results.length > 0) return results;
-            const fuzzy = await this.searchTracksTrigram({ query, limit, offset });
-            return fuzzy.length > 0
-                ? fuzzy
-                : this.searchTracksFallback({ query, limit, offset });
+            return this.searchTracksFallback({ query, limit, offset });
         } catch (error) {
             logger.error("Track search error:", error);
             return this.searchTracksFallback({ query, limit, offset });
@@ -916,13 +832,42 @@ export class SearchService {
                 this.searchEpisodes({ query, limit }),
             ]);
 
-        const results = {
+        const filteredTracks = genre
+            ? await this.filterTracksByGenre(tracks, genre)
+            : tracks;
+
+        // Cross-type top result: highest-rank item across the first (already
+        // rank-sorted desc) entry of each music type. Tie-break artist > album
+        // > track, achieved by considering them in that order with strict `>`.
+        let topResult: SearchResults["topResult"];
+        const candidates: Array<{
+            type: "artist" | "album" | "track";
+            id: string;
+            rank: number;
+        }> = [];
+        if (artists[0]) {
+            candidates.push({ type: "artist", id: artists[0].id, rank: artists[0].rank });
+        }
+        if (albums[0]) {
+            candidates.push({ type: "album", id: albums[0].id, rank: albums[0].rank });
+        }
+        if (filteredTracks[0]) {
+            candidates.push({ type: "track", id: filteredTracks[0].id, rank: filteredTracks[0].rank });
+        }
+        for (const c of candidates) {
+            if (!topResult || c.rank > topResult.rank) {
+                topResult = c;
+            }
+        }
+
+        const results: SearchResults = {
             artists,
             albums,
-            tracks: genre ? await this.filterTracksByGenre(tracks, genre) : tracks,
+            tracks: filteredTracks,
             podcasts,
             audiobooks,
             episodes,
+            ...(topResult ? { topResult } : {}),
         };
 
         // Cache for 5 minutes (balance freshness vs performance)
@@ -1050,9 +995,10 @@ export class SearchService {
 
         // Record genuine DB misses (cache-miss branch only) when the requested
         // type returned nothing.
-        if (
-            (results[type as keyof SearchResults] ?? []).length === 0
-        ) {
+        const typedResults = results[
+            type as Exclude<keyof SearchResults, "topResult">
+        ];
+        if ((typedResults ?? []).length === 0) {
             await this.recordZeroResult(query);
         }
 

--- a/backend/src/workers/artistEnrichment.ts
+++ b/backend/src/workers/artistEnrichment.ts
@@ -91,6 +91,7 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
             ? artist.heroUrl
             : null;
         let genres: string[] = [];
+        let aliases: string[] = [];
 
         if (!artist.mbid.startsWith("temp-")) {
             logger.debug(
@@ -215,11 +216,13 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
             }
         }
 
-        // Genre fallback: MusicBrainz curated genres (if Last.fm didn't return any)
-        if (genres.length === 0 && !artist.mbid.startsWith("temp-")) {
+        // MusicBrainz: curated genres (fallback if Last.fm returned none) + aliases.
+        // Aliases always need MB, so fetch unconditionally for real MBIDs; genres
+        // are only used when Last.fm gave us nothing.
+        if (!artist.mbid.startsWith("temp-")) {
             try {
-                const mbArtist = await musicBrainzService.getArtist(artist.mbid, ["genres"]);
-                if (mbArtist?.genres && Array.isArray(mbArtist.genres)) {
+                const mbArtist = await musicBrainzService.getArtist(artist.mbid, ["genres", "aliases"]);
+                if (genres.length === 0 && mbArtist?.genres && Array.isArray(mbArtist.genres)) {
                     genres = mbArtist.genres
                         .sort((a: any, b: any) => (b.count || 0) - (a.count || 0))
                         .slice(0, 5)
@@ -229,8 +232,29 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
                         logger.debug(`${logPrefix} MusicBrainz: ${genres.length} genres: ${genres.join(', ')}`);
                     }
                 }
+                // Alternate names (e.g. "JAY-Z"/"Jay Z", localized/stage names).
+                // These flow into the artist searchVector (weight B) so full-text
+                // search can match an artist by an alias with no query change.
+                if (mbArtist?.aliases && Array.isArray(mbArtist.aliases)) {
+                    const primaryLower = artist.name.toLowerCase();
+                    const seen = new Set<string>();
+                    aliases = mbArtist.aliases
+                        .map((a: any) => (a?.name || "").trim())
+                        .filter((name: string) => {
+                            if (!name) return false;
+                            if (name.toLowerCase() === primaryLower) return false;
+                            const key = name.toLowerCase();
+                            if (seen.has(key)) return false;
+                            seen.add(key);
+                            return true;
+                        })
+                        .slice(0, 25);
+                    if (aliases.length > 0) {
+                        logger.debug(`${logPrefix} MusicBrainz: ${aliases.length} aliases: ${aliases.join(', ')}`);
+                    }
+                }
             } catch (error: any) {
-                logger.debug(`${logPrefix} MusicBrainz genres: FAILED - ${error?.message || error}`);
+                logger.debug(`${logPrefix} MusicBrainz genres/aliases: FAILED - ${error?.message || error}`);
             }
         }
 
@@ -310,6 +334,7 @@ export async function enrichSimilarArtist(artist: Artist): Promise<void> {
                 heroUrl: finalHeroUrl,
                 similarArtistsJson,
                 genres: genres.length > 0 ? genres : undefined,
+                aliases: aliases.length > 0 ? aliases : undefined,
                 lastEnriched: new Date(),
                 enrichmentStatus: "completed",
             },

--- a/frontend/components/layout/TopBar.tsx
+++ b/frontend/components/layout/TopBar.tsx
@@ -15,6 +15,7 @@ import {
 import { ActivityPanelToggle } from "./ActivityPanel";
 import { cn } from "@/utils/cn";
 import { api } from "@/lib/api";
+import { useSearchSuggest } from "@/hooks/useSearchSuggest";
 import { useToast } from "@/lib/toast-context";
 import { useDownloadContext } from "@/lib/download-context";
 import { useQuery } from "@tanstack/react-query";
@@ -42,6 +43,20 @@ export function TopBar() {
     const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
     const searchInputRef = useRef<HTMLInputElement | null>(null);
     const queryClient = useQueryClient();
+
+    // Phase H: typeahead suggestions dropdown (additive -- does not alter the
+    // existing Enter/submit + 500ms auto-navigate behaviour above).
+    const [suggestOpen, setSuggestOpen] = useState(false);
+    const { suggestions } = useSearchSuggest(searchQuery);
+    const hasSuggestions =
+        suggestions.artists.length > 0 || suggestions.albums.length > 0;
+    const showSuggest =
+        suggestOpen && searchQuery.trim().length >= 2 && hasSuggestions;
+
+    const goToSuggestion = (href: string) => {
+        setSuggestOpen(false);
+        router.push(href);
+    };
 
     // SSE-populated scan status (populated by useEventSource via queryClient.setQueryData)
     const { data: scanStatus } = useQuery<{
@@ -112,9 +127,87 @@ export function TopBar() {
 
     const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
+        setSuggestOpen(false);
         if (searchQuery.trim()) {
             router.push(`/search?q=${encodeURIComponent(searchQuery.trim())}`);
         }
+    };
+
+    // Shared dropdown of typeahead suggestions, rendered under each search input.
+    const renderSuggestDropdown = () => {
+        if (!showSuggest) return null;
+        return (
+            <div
+                className="absolute left-0 right-0 top-full mt-2 bg-[#0f0f0f] border border-[#262626] rounded-xl shadow-2xl overflow-hidden z-50 max-h-[60vh] overflow-y-auto"
+                // Keep the dropdown open while interacting with it; blur fires
+                // before click, so suppress the mousedown-driven close.
+                onMouseDown={(e) => e.preventDefault()}
+            >
+                {suggestions.artists.length > 0 && (
+                    <div className="py-1">
+                        <div className="px-3 py-1 text-[10px] uppercase tracking-wide text-gray-500">
+                            Artists
+                        </div>
+                        {suggestions.artists.map((artist) => (
+                            <button
+                                key={`artist-${artist.id}`}
+                                type="button"
+                                onClick={() => goToSuggestion(`/artist/${artist.id}`)}
+                                className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-white/5 transition-colors"
+                            >
+                                {artist.heroUrl ? (
+                                    // eslint-disable-next-line @next/next/no-img-element
+                                    <img
+                                        src={api.getCoverArtUrl(artist.heroUrl, 64)}
+                                        alt=""
+                                        className="w-8 h-8 rounded-full object-cover flex-shrink-0"
+                                    />
+                                ) : (
+                                    <span className="w-8 h-8 rounded-full bg-[#262626] flex-shrink-0" />
+                                )}
+                                <span className="truncate text-sm text-white">
+                                    {artist.name}
+                                </span>
+                            </button>
+                        ))}
+                    </div>
+                )}
+                {suggestions.albums.length > 0 && (
+                    <div className="py-1 border-t border-[#1a1a1a]">
+                        <div className="px-3 py-1 text-[10px] uppercase tracking-wide text-gray-500">
+                            Albums
+                        </div>
+                        {suggestions.albums.map((album) => (
+                            <button
+                                key={`album-${album.id}`}
+                                type="button"
+                                onClick={() => goToSuggestion(`/album/${album.id}`)}
+                                className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-white/5 transition-colors"
+                            >
+                                {album.coverUrl ? (
+                                    // eslint-disable-next-line @next/next/no-img-element
+                                    <img
+                                        src={api.getCoverArtUrl(album.coverUrl, 64)}
+                                        alt=""
+                                        className="w-8 h-8 rounded object-cover flex-shrink-0"
+                                    />
+                                ) : (
+                                    <span className="w-8 h-8 rounded bg-[#262626] flex-shrink-0" />
+                                )}
+                                <span className="min-w-0">
+                                    <span className="block truncate text-sm text-white">
+                                        {album.title}
+                                    </span>
+                                    <span className="block truncate text-xs text-gray-400">
+                                        {album.artistName}
+                                    </span>
+                                </span>
+                            </button>
+                        ))}
+                    </div>
+                )}
+            </div>
+        );
     };
 
     // Auto-search with debounce (500ms after user stops typing)
@@ -251,7 +344,12 @@ export function TopBar() {
                             <input
                                 type="text"
                                 value={searchQuery}
-                                onChange={(e) => setSearchQuery(e.target.value)}
+                                onChange={(e) => {
+                                    setSearchQuery(e.target.value);
+                                    setSuggestOpen(true);
+                                }}
+                                onFocus={() => setSuggestOpen(true)}
+                                onBlur={() => setSuggestOpen(false)}
                                 placeholder="Search..."
                                 aria-label="Search"
                                 autoCapitalize="none"
@@ -259,6 +357,7 @@ export function TopBar() {
                                 tabIndex={0}
                                 className="w-full h-10 pl-10 pr-3 bg-[var(--bg-hover)] hover:bg-[#242424] border-2 border-transparent focus:border-white/20 rounded-full text-sm text-white placeholder-gray-400 transition-all outline-none"
                             />
+                            {renderSuggestDropdown()}
                         </div>
                     </form>
 
@@ -330,9 +429,12 @@ export function TopBar() {
                                     ref={searchInputRef}
                                     type="text"
                                     value={searchQuery}
-                                    onChange={(e) =>
-                                        setSearchQuery(e.target.value)
-                                    }
+                                    onChange={(e) => {
+                                        setSearchQuery(e.target.value);
+                                        setSuggestOpen(true);
+                                    }}
+                                    onFocus={() => setSuggestOpen(true)}
+                                    onBlur={() => setSuggestOpen(false)}
                                     placeholder="What do you want to play?"
                                     aria-label="Search"
                                     autoCapitalize="none"
@@ -340,6 +442,7 @@ export function TopBar() {
                                     tabIndex={0}
                                     className="w-full h-12 pl-12 pr-4 bg-[var(--bg-hover)] hover:bg-[#242424] border-2 border-transparent focus:border-white/20 rounded-full text-sm text-white placeholder-gray-400 transition-all outline-none"
                                 />
+                                {renderSuggestDropdown()}
                             </div>
                         </form>
                     </div>

--- a/frontend/components/layout/TopBar.tsx
+++ b/frontend/components/layout/TopBar.tsx
@@ -342,7 +342,13 @@ export function TopBar() {
                         >
                             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
                             <input
-                                type="text"
+                                type="search"
+                                name="q"
+                                autoComplete="off"
+                                data-1p-ignore="true"
+                                data-lpignore="true"
+                                data-bwignore="true"
+                                data-form-type="other"
                                 value={searchQuery}
                                 onChange={(e) => {
                                     setSearchQuery(e.target.value);
@@ -427,7 +433,13 @@ export function TopBar() {
                                 <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                                 <input
                                     ref={searchInputRef}
-                                    type="text"
+                                    type="search"
+                                    name="q"
+                                    autoComplete="off"
+                                    data-1p-ignore="true"
+                                    data-lpignore="true"
+                                    data-bwignore="true"
+                                    data-form-type="other"
                                     value={searchQuery}
                                     onChange={(e) => {
                                         setSearchQuery(e.target.value);

--- a/frontend/hooks/useSearchSuggest.ts
+++ b/frontend/hooks/useSearchSuggest.ts
@@ -1,0 +1,53 @@
+/**
+ * Phase H: typeahead/suggest hook for the global search box.
+ *
+ * Debounces the raw input (~200ms) and fetches a small, ranked set of artist +
+ * album suggestions from GET /api/search/suggest. Backed by React Query so
+ * repeated queries are cached and in-flight requests are aborted on change.
+ * Returns empty for queries shorter than 2 chars (matches the backend guard).
+ */
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export interface SuggestArtist {
+    id: string;
+    name: string;
+    heroUrl: string | null;
+}
+
+export interface SuggestAlbum {
+    id: string;
+    title: string;
+    artistName: string;
+    coverUrl: string | null;
+}
+
+export interface SuggestResults {
+    artists: SuggestArtist[];
+    albums: SuggestAlbum[];
+}
+
+export function useSearchSuggest(query: string, debounceMs: number = 200) {
+    const [debounced, setDebounced] = useState("");
+
+    useEffect(() => {
+        const trimmed = query.trim();
+        const handle = setTimeout(() => setDebounced(trimmed), debounceMs);
+        return () => clearTimeout(handle);
+    }, [query, debounceMs]);
+
+    const enabled = debounced.length >= 2;
+
+    const { data, isFetching } = useQuery<SuggestResults>({
+        queryKey: ["search-suggest", debounced],
+        queryFn: ({ signal }) => api.getSearchSuggest(debounced, signal),
+        enabled,
+        staleTime: 60 * 1000, // mirrors the backend 60s cache
+    });
+
+    return {
+        suggestions: enabled ? data ?? { artists: [], albums: [] } : { artists: [], albums: [] },
+        isFetching: enabled && isFetching,
+    };
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1228,6 +1228,19 @@ class ApiClient {
         );
     }
 
+    // Lightweight typeahead/suggest for the search box (artists + albums)
+    async getSearchSuggest(query: string, signal?: AbortSignal) {
+        return this.request<{
+            artists: Array<{ id: string; name: string; heroUrl: string | null }>;
+            albums: Array<{
+                id: string;
+                title: string;
+                artistName: string;
+                coverUrl: string | null;
+            }>;
+        }>(`/search/suggest?q=${encodeURIComponent(query)}`, { signal });
+    }
+
     async discoverSearch(
         query: string,
         type: "music" | "podcasts" | "all" = "music",


### PR DESCRIPTION
## Description

Overhauls library search. Replaces the prior matching with Postgres full-text search unified with `pg_trgm` trigram fuzzy matching for typo tolerance, adds a phonetic artist fallback, a bounded ownership/popularity ranking boost with a cross-type "top result", indexes MusicBrainz artist aliases into the search vector, and adds a typeahead `/suggest` endpoint with a search-box dropdown.

Open question on the migration strategy — see Notes.

## Type of Change

-   [x] New feature (non-breaking change that adds functionality)
-   [x] Enhancement (improvement to existing functionality)

## Changes Made

-   `pg_trgm` trigram fuzzy fallback for typo tolerance
-   Unified FTS + trigram ranking with a cross-type top result
-   Simple FTS text-search config for music + a `normalizedName` trigram index
-   Bounded ownership/popularity boost in ranking (capped via `LEAST`, no unbounded signal, no divide-by-zero)
-   Index MusicBrainz artist aliases into the search vector for alias-aware artist search
-   Short-query handling + phonetic artist fallback (`fuzzystrmatch`/`dmetaphone`)
-   Typeahead `GET /search/suggest` endpoint + search-box dropdown (`useSearchSuggest` hook with stale-response/abort handling)
-   Log zero-result queries to a bounded Redis miss-list (top-500, 30-day TTL) for tuning
-   Stop password managers autofilling the search box

## Testing Done

-   [x] Tested locally with Docker
-   [x] Search + typeahead exercised against a ~15k-track library

## Notes / open for discussion

-   The migrations backfill `searchVector`/`normalizedName` with full-table `UPDATE`s and create the GIN/trigram indexes **non-`CONCURRENTLY`**. That's fine on my library but holds a brief table lock; on a very large library this would be better batched or run `CONCURRENTLY`. Can rework before merge if you'd prefer.
-   `/search/suggest` runs FTS + trigram (+ phonetic on miss). It's behind the existing `apiLimiter` and debounced client-side; a dedicated tighter per-endpoint limit could be added if you'd like.
-   All raw SQL uses parameterised `Prisma.sql` templates; the `to_tsquery` input is additionally sanitised to `\w`-only tokens.

## Checklist

-   [x] My code follows the project's code style
-   [x] I have tested my changes locally
-   [ ] I have updated documentation if needed
-   [x] My changes don't introduce new warnings
-   [x] This PR targets the `main` branch

