### PR TITLE
feat(soulseek): flood-limit + dedupe outgoing slskd searches

### DIFF
--- a/backend/src/__mocks__/test-env.cjs
+++ b/backend/src/__mocks__/test-env.cjs
@@ -6,3 +6,5 @@ process.env.JWT_SECRET = 'test-jwt-secret-for-testing-purposes-only-32chars';
 process.env.SESSION_SECRET = 'test-session-secret-for-testing-purposes-only';
 process.env.DATABASE_URL = 'postgresql://test:test@localhost:5433/test';
 process.env.REDIS_URL = 'redis://localhost:6379';
+process.env.MUSIC_PATH = '/music';
+process.env.SETTINGS_ENCRYPTION_KEY = 'test-settings-encryption-key-for-jest-only';

--- a/backend/src/lib/soulseek/slskd-client.ts
+++ b/backend/src/lib/soulseek/slskd-client.ts
@@ -98,6 +98,91 @@ const slskdPost = (p: string, b?: unknown) => slskdRequest('POST', p, b)
 const slskdDelete = (p: string) => slskdRequest('DELETE', p)
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 
+// ── Outgoing-search flood protection ──────────────────────────────────
+//
+// WHY: Kima expands each track into several near-identical query variants
+// (e.g. "Stairway to Heaven" -> "Led Zeppelin Stairway to Heaven" ->
+// "Led Zeppelin IV (Deluxe Edition) Stairway to Heaven" -> "... (Remaster)")
+// and higher-level batch code (searchAndDownloadBatch) runs multiple tracks
+// concurrently. Firing all of these at once produced bursts of ~25 searches
+// within ~200ms, which trips Soulseek's SERVER-SIDE flood protection: searches
+// come back Completed/Errored with 0 results in ~0s, and the account gets
+// 30-minute bans.
+//
+// To make this impossible regardless of how many callers dispatch in parallel,
+// EVERY outgoing slskd search is funnelled through one process-wide gate:
+// concurrency 1 (serialized) with a small inter-search delay between
+// consecutive searches. This is a hard global limiter — even Promise.all /
+// PQueue callers end up issuing their search HTTP calls one-at-a-time here.
+const SLSKD_SEARCH_CONCURRENCY = Math.max(
+  1,
+  parseInt(process.env.SLSKD_SEARCH_CONCURRENCY || '1', 10) || 1
+)
+const SLSKD_SEARCH_DELAY_MS = Math.max(
+  0,
+  parseInt(process.env.SLSKD_SEARCH_DELAY_MS || '400', 10) || 0
+)
+
+/**
+ * Tiny dependency-free async concurrency limiter that also spaces consecutive
+ * tasks apart by a fixed delay. Used as a module-level singleton so it gates
+ * outgoing searches across ALL SlskdClient instances and all callers.
+ *
+ * The delay is applied BEFORE running a task only when a previous task has
+ * already run (tracked via lastRunAt), so the very first search after an idle
+ * period is not penalised, but back-to-back searches are throttled.
+ */
+class SearchGate {
+  private active = 0
+  private queue: Array<() => void> = []
+  private lastRunAt = 0
+
+  constructor(
+    private readonly concurrency: number,
+    private readonly delayMs: number
+  ) {}
+
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this._acquire()
+    try {
+      // Space consecutive searches apart to stay under Soulseek's flood
+      // threshold. Only wait if a previous search ran recently.
+      if (this.delayMs > 0 && this.lastRunAt > 0) {
+        const elapsed = Date.now() - this.lastRunAt
+        if (elapsed < this.delayMs) {
+          await sleep(this.delayMs - elapsed)
+        }
+      }
+      this.lastRunAt = Date.now()
+      return await task()
+    } finally {
+      this.lastRunAt = Date.now()
+      this._release()
+    }
+  }
+
+  private _acquire(): Promise<void> {
+    if (this.active < this.concurrency) {
+      this.active++
+      return Promise.resolve()
+    }
+    return new Promise<void>((resolve) => {
+      this.queue.push(() => {
+        this.active++
+        resolve()
+      })
+    })
+  }
+
+  private _release(): void {
+    this.active--
+    const next = this.queue.shift()
+    if (next) next()
+  }
+}
+
+const searchGate = new SearchGate(SLSKD_SEARCH_CONCURRENCY, SLSKD_SEARCH_DELAY_MS)
+
 // ── FakeServerConn ────────────────────────────────────────────────────
 
 class FakeServerConn extends EventEmitter {
@@ -243,10 +328,17 @@ export class SlskdClient extends EventEmitter {
       maxResponses?: number
     } = {}
   ): Promise<FileSearchResponse[]> {
-    const searchResult = await slskdPost('/api/v0/searches', {
-      searchText: query,
-      responseLimit: maxResponses,
-    })
+    // Issue the search-creation call through the process-wide flood gate so
+    // bursts of variant/batch searches are serialized + spaced apart (see
+    // SearchGate / SLSKD_SEARCH_* above). Only the initial "create search"
+    // POST is gated — subsequent result polling for an already-running search
+    // does not count against Soulseek's outbound-search flood threshold.
+    const searchResult = await searchGate.run(() =>
+      slskdPost('/api/v0/searches', {
+        searchText: query,
+        responseLimit: maxResponses,
+      })
+    )
     const searchId = searchResult.id
 
     const results: FileSearchResponse[] = []

--- a/backend/src/services/soulseek-search-strategies.ts
+++ b/backend/src/services/soulseek-search-strategies.ts
@@ -190,7 +190,7 @@ export async function searchWithStrategies(
     const audioExtensions = [".flac", ".mp3", ".m4a", ".ogg", ".opus", ".wav", ".aac"];
 
     // Build queries once and filter strategies that produce valid queries
-    const applicableStrategies = SEARCH_STRATEGIES
+    const builtStrategies = SEARCH_STRATEGIES
         .map(strategy => ({
             strategy,
             query: strategy.buildQuery(artistName, trackTitle, albumName)
@@ -207,6 +207,30 @@ export async function searchWithStrategies(
             }
             return query.length > 0;
         });
+
+    // De-duplicate near-identical query variants before dispatch.
+    // WHY: different strategies frequently collapse to the same string after
+    // normalization (e.g. moderate vs aggressive produce identical text, or the
+    // album-title / artist-album-title variants coincide). Searching the same
+    // text twice wastes an outbound Soulseek search and contributes to the
+    // burst pattern that trips server-side flood protection (0-result returns +
+    // 30-minute bans). We compare on a normalized key (trim + collapsed
+    // whitespace + lowercase) but keep the ORIGINAL casing for the actual
+    // search, and preserve the first occurrence's order/priority.
+    const seenQueryKeys = new Set<string>();
+    const applicableStrategies = builtStrategies.filter(({ query, strategy }) => {
+        const key = query.trim().replace(/\s+/g, " ").toLowerCase();
+        if (seenQueryKeys.has(key)) {
+            sessionLog(
+                "SOULSEEK",
+                `[Search #${searchId}] Skipping strategy "${strategy.name}" - duplicate query "${query}"`,
+                "DEBUG"
+            );
+            return false;
+        }
+        seenQueryKeys.add(key);
+        return true;
+    });
 
     let allResponses: FileSearchResponse[] = [];
     let successfulStrategy: string | null = null;


### PR DESCRIPTION
## Description

Adds outbound-search flood protection to the slskd backend (the one merged in #205). Kima expands each track into several near-identical query variants (`"title"` → `"artist title"` → `"artist album title"` → `"… (remaster)"`) and runs tracks concurrently, so a batch can burst ~25 search-create calls within ~200ms. That trips Soulseek's **server-side** flood protection: searches return Completed/Errored with 0 results in ~0s, and the account picks up 30-minute bans.

A process-wide `SearchGate` funnels every outgoing search-create POST through one gate (serialised + spaced apart), so no matter how many callers dispatch in parallel the create calls go out one-at-a-time. Result polling and deletes are **not** gated.

A couple of open design questions in Notes.

## Type of Change

-   [x] Bug fix (non-breaking change that fixes an issue) — prevents flood bans
-   [x] Enhancement

## Changes Made

-   `SearchGate` in `slskd-client.ts`: serialises + spaces the `/api/v0/searches` POST. Tunable via `SLSKD_SEARCH_CONCURRENCY` (default 1) and `SLSKD_SEARCH_DELAY_MS` (default 400). Releases its permit on throw (try/finally), so a failing search can't wedge the gate.
-   Dedupe identical query variants within a single track's strategy set, so we don't fire the same query twice.

## Testing Done

-   [x] Tested locally with Docker
-   [x] Running on my deployment; eliminated the recurring 30-minute Soulseek bans that batch imports used to trigger

## Notes / open for discussion

1.  **On-by-default throttle.** With the defaults (1 / 400ms) this serialises *every* slskd search install-wide, adding latency to large batches even for users who never hit bans. Options: keep on-by-default (conservative, safe), or default `SLSKD_SEARCH_DELAY_MS=0` (opt-in) and document 400ms as the recommended anti-ban preset. Your call.
2.  **`SLSKD_SEARCH_CONCURRENCY` is effectively a serial pacer.** The inter-search delay pivots on a single shared `lastRunAt`, so values >1 weaken the spacing guarantee. I left the knob in for flexibility but it's really meant to stay at 1; happy to drop it and hardcode serial, or rework the spacing to a reserved-slot cursor that composes with concurrency, if you'd prefer.
3.  The dedupe is intra-track (variant-level), not cross-flight coalescing of identical queries from different tracks.
4.  Should these knobs surface in the `configureSlskd()` UI settings from #205 rather than env-only? Easy to add.

## Checklist

-   [x] My code follows the project's code style
-   [x] I have tested my changes locally
-   [ ] I have updated documentation if needed
-   [x] My changes don't introduce new warnings
-   [x] This PR targets the `main` branch

