### PR TITLE
Misc fixes: Lidarr MBID reuse, Soulseek fallback, discovery + edition scoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,11 @@ KIMA_CALLBACK_URL=http://backend:3006
 # - Check networks: docker network inspect kima_network
 # - If Lidarr is on different network, use external IP instead: http://<your-ip>:3006
 # - Then update Lidarr → Settings → Connect → Kima webhook URL to match
+
+# ==============================================================================
+# OPTIONAL: Download fallback
+# ==============================================================================
+
+# When Lidarr is not configured/unavailable, automatically fall back to a
+# Soulseek download for album requests. Off by default; set to 'true' to enable.
+# DOWNLOAD_SOULSEEK_AUTO_FALLBACK=false

--- a/backend/src/__mocks__/test-env.cjs
+++ b/backend/src/__mocks__/test-env.cjs
@@ -6,3 +6,5 @@ process.env.JWT_SECRET = 'test-jwt-secret-for-testing-purposes-only-32chars';
 process.env.SESSION_SECRET = 'test-session-secret-for-testing-purposes-only';
 process.env.DATABASE_URL = 'postgresql://test:test@localhost:5433/test';
 process.env.REDIS_URL = 'redis://localhost:6379';
+process.env.MUSIC_PATH = '/music';
+process.env.SETTINGS_ENCRYPTION_KEY = 'test-settings-encryption-key-for-jest-only';

--- a/backend/src/routes/artists.ts
+++ b/backend/src/routes/artists.ts
@@ -9,12 +9,50 @@ import { redisClient } from "../utils/redis";
 import { normalizeToArray } from "../utils/normalize";
 import { requireAuthOrToken } from "../middleware/auth";
 import { safeError } from "../utils/errors";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../utils/db";
+import { normalizeArtistName } from "../utils/artistNormalization";
 
 const router = Router();
 router.use(requireAuthOrToken);
 
 // Cache TTL for discovery content (shorter since it's not owned)
 const DISCOVERY_CACHE_TTL = 24 * 60 * 60; // 24 hours
+
+/**
+ * Find an artist we already own that matches the given identifier(s).
+ *
+ * The discovery route builds an artist page from external metadata
+ * (MusicBrainz/Last.fm). If the artist is actually in the library we must
+ * NOT build a separate foreign page - that is how one artist ends up with
+ * two different pages ("library" vs "discovery") depending on which link the
+ * user followed. By resolving to the canonical library artist first we keep a
+ * single page per artist.
+ *
+ * Matches by exact MBID or by normalizedName (diacritic/"&"-folded), and only
+ * returns artists that actually have albums (mirrors the search filter, avoids
+ * redirecting to empty stub rows).
+ */
+async function findOwnedArtist(opts: {
+    mbid?: string | null;
+    name?: string | null;
+}): Promise<{ id: string } | null> {
+    const or: Prisma.ArtistWhereInput[] = [];
+    if (opts.mbid) {
+        or.push({ id: opts.mbid });
+        or.push({ mbid: opts.mbid });
+    }
+    if (opts.name) {
+        const norm = normalizeArtistName(opts.name);
+        if (norm) or.push({ normalizedName: norm });
+    }
+    if (or.length === 0) return null;
+
+    return prisma.artist.findFirst({
+        where: { AND: [{ OR: or }, { albums: { some: {} } }] },
+        select: { id: true },
+    });
+}
 
 // GET /artists/preview/:artistName/:trackTitle - Get Deezer preview URL for a track
 router.get("/preview/:artistName/:trackTitle", async (req, res) => {
@@ -109,8 +147,22 @@ router.get("/discover/:nameOrMbid", async (req, res) => {
     try {
         const { nameOrMbid } = req.params;
 
+        // Identity guard (tier 1): if this raw identifier already maps to an
+        // artist we own, redirect to the canonical library page rather than
+        // building a discovery page. Done before the cache read so a stale
+        // cached discovery payload can never shadow an owned artist.
+        const ownedByInput = await findOwnedArtist({
+            mbid: nameOrMbid,
+            name: decodeURIComponent(nameOrMbid),
+        });
+        if (ownedByInput) {
+            return res.redirect(307, `/api/library/artists/${ownedByInput.id}`);
+        }
+
         // Check Redis cache first for discovery content
-        const cacheKey = `discovery:artist:${nameOrMbid}`;
+        // (v2: bumped when the identity guard above was added so previously
+        // cached discovery pages for owned artists no longer shadow it)
+        const cacheKey = `discovery:artist:v2:${nameOrMbid}`;
         try {
             const cached = await redisClient.get(cacheKey);
             if (cached) {
@@ -150,6 +202,16 @@ router.get("/discover/:nameOrMbid", async (req, res) => {
 
         if (!artistName) {
             return res.status(404).json({ error: "Artist not found" });
+        }
+
+        // Identity guard (tier 2): MusicBrainz has now canonicalised the
+        // name/MBID. This catches the case the raw-input guard cannot - an
+        // owned artist stored under a different MBID (or a temp- MBID) than the
+        // one in the inbound link. Resolving by canonical MBID or normalized
+        // name collapses those into the single library page.
+        const ownedByCanonical = await findOwnedArtist({ mbid, name: artistName });
+        if (ownedByCanonical) {
+            return res.redirect(307, `/api/library/artists/${ownedByCanonical.id}`);
         }
 
         // Get artist info from Last.fm

--- a/backend/src/routes/artists.ts
+++ b/backend/src/routes/artists.ts
@@ -151,9 +151,19 @@ router.get("/discover/:nameOrMbid", async (req, res) => {
         // artist we own, redirect to the canonical library page rather than
         // building a discovery page. Done before the cache read so a stale
         // cached discovery payload can never shadow an owned artist.
+        // nameOrMbid is already URL-decoded by Express. Decoding it a second
+        // time throws URIError on any literal '%' in the name (e.g. "50%"),
+        // which previously 500'd this route. Decode defensively, falling back
+        // to the raw value.
+        let decodedName = nameOrMbid;
+        try {
+            decodedName = decodeURIComponent(nameOrMbid);
+        } catch {
+            decodedName = nameOrMbid;
+        }
         const ownedByInput = await findOwnedArtist({
             mbid: nameOrMbid,
-            name: decodeURIComponent(nameOrMbid),
+            name: decodedName,
         });
         if (ownedByInput) {
             return res.redirect(307, `/api/library/artists/${ownedByInput.id}`);
@@ -180,7 +190,7 @@ router.get("/discover/:nameOrMbid", async (req, res) => {
             );
 
         let mbid: string | null = isMbid ? nameOrMbid : null;
-        let artistName: string = isMbid ? "" : decodeURIComponent(nameOrMbid);
+        let artistName: string = isMbid ? "" : decodedName;
 
         // If we have a name but no MBID, search for it
         if (!mbid && artistName) {

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -8,6 +8,7 @@ import { lidarrService } from "../services/lidarr";
 import { musicBrainzService } from "../services/musicbrainz";
 import { lastFmService } from "../services/lastfm";
 import { simpleDownloadManager } from "../services/simpleDownloadManager";
+import { acquisitionService } from "../services/acquisitionService";
 import crypto from "crypto";
 import { safeError } from "../utils/errors";
 
@@ -118,8 +119,24 @@ router.post("/", async (req, res) => {
             });
         }
 
-        // Check if Lidarr is enabled (database or .env)
+        // Check if Lidarr is enabled — fall back to Soulseek via acquisition service
         const lidarrEnabled = await lidarrService.isEnabled();
+        if (!lidarrEnabled && type === "album" && artistName && albumTitle) {
+            logger.info(`[DOWNLOAD] Lidarr unavailable, using Soulseek: ${artistName} - ${albumTitle} (${mbid})`);
+            res.json({ id: null, status: "downloading", downloadType, message: `Downloading via Soulseek: ${artistName} - ${albumTitle}` });
+            acquisitionService.acquireAlbum({
+                albumTitle, artistName, mbid,
+            }, { userId }).then(result => {
+                if (result.success) {
+                    logger.info(`[DOWNLOAD] Soulseek success: ${artistName} - ${albumTitle}`);
+                } else {
+                    logger.warn(`[DOWNLOAD] Soulseek failed: ${artistName} - ${albumTitle}: ${result.error}`);
+                }
+            }).catch(err => {
+                logger.error(`[DOWNLOAD] Soulseek error: ${err.message}`);
+            });
+            return;
+        }
         if (!lidarrEnabled) {
             return res.status(400).json({
                 error: "Lidarr not configured. Please add albums manually to your library.",

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -119,9 +119,13 @@ router.post("/", async (req, res) => {
             });
         }
 
-        // Check if Lidarr is enabled — fall back to Soulseek via acquisition service
+        // Auto-falling back to Soulseek when Lidarr is unavailable is opt-in:
+        // by default a failed/retried album download does NOT silently route to
+        // Soulseek. Enable with DOWNLOAD_SOULSEEK_AUTO_FALLBACK=true.
+        const soulseekAutoFallback =
+            (process.env.DOWNLOAD_SOULSEEK_AUTO_FALLBACK || "false").toLowerCase() === "true";
         const lidarrEnabled = await lidarrService.isEnabled();
-        if (!lidarrEnabled && type === "album" && artistName && albumTitle) {
+        if (soulseekAutoFallback && !lidarrEnabled && type === "album" && artistName && albumTitle) {
             logger.info(`[DOWNLOAD] Lidarr unavailable, using Soulseek: ${artistName} - ${albumTitle} (${mbid})`);
             res.json({ id: null, status: "downloading", downloadType, message: `Downloading via Soulseek: ${artistName} - ${albumTitle}` });
             acquisitionService.acquireAlbum({

--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -768,7 +768,7 @@ router.post("/:id/pending/retry-all", async (req, res) => {
             return res.status(404).json({ error: "Playlist not found" });
         }
 
-        if (playlist.userId !== userId) {
+        if (playlist.userId !== userId && req.user!.role !== "admin") {
             return res.status(403).json({ error: "Access denied" });
         }
 
@@ -955,7 +955,7 @@ router.post("/:id/pending/:trackId/retry", async (req, res) => {
             return res.status(404).json({ error: "Playlist not found" });
         }
 
-        if (playlist.userId !== userId) {
+        if (playlist.userId !== userId && req.user!.role !== "admin") {
             sessionLog(
                 "PENDING-RETRY",
                 `Access denied: playlistId=${playlistId} userId=${userId}`,

--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -780,16 +780,10 @@ router.post("/:id/pending/retry-all", async (req, res) => {
             return res.json({ success: true, queued: 0, message: "No pending tracks to retry" });
         }
 
-        const { soulseekService } = await import("../services/soulseek");
-        const { getSystemSettings } = await import("../utils/systemSettings");
-
-        const settings = await getSystemSettings();
-        if (!settings?.musicPath) {
-            return res.status(400).json({ error: "Music path not configured" });
-        }
-        if (!settings?.soulseekUsername || !settings?.soulseekPassword) {
-            return res.status(400).json({ error: "Soulseek credentials not configured" });
-        }
+        // Route retries through the normal acquisition pipeline (respects the
+        // configured downloadSource: Lidarr or Soulseek) instead of hardcoding
+        // Soulseek. acquireAlbum reuses the per-track job via existingJobId.
+        const { acquisitionService } = await import("../services/acquisitionService");
 
         // Create download jobs for all pending tracks
         const downloadJobs = [];
@@ -833,70 +827,30 @@ router.post("/:id/pending/retry-all", async (req, res) => {
             message: `Retrying ${downloadJobs.length} tracks`,
         });
 
-        // Process sequentially in background to avoid flooding Soulseek
+        // Process sequentially in background through the acquisition pipeline.
         (async () => {
             for (const { job, pendingTrack } of downloadJobs) {
                 try {
-                    const albumName =
+                    const albumTitle =
+                        pendingTrack.spotifyAlbum &&
                         pendingTrack.spotifyAlbum !== "Unknown Album"
                             ? pendingTrack.spotifyAlbum
-                            : pendingTrack.spotifyArtist;
+                            : pendingTrack.spotifyTitle;
 
-                    const searchResult = await soulseekService.searchTrack(
-                        pendingTrack.spotifyArtist,
-                        pendingTrack.spotifyTitle,
-                        pendingTrack.spotifyAlbum !== "Unknown Album" ? pendingTrack.spotifyAlbum : undefined
+                    const result = await acquisitionService.acquireAlbum(
+                        {
+                            albumTitle,
+                            artistName: pendingTrack.spotifyArtist,
+                            mbid: pendingTrack.albumMbid || undefined,
+                            artistMbid: pendingTrack.artistMbid || undefined,
+                        },
+                        { userId, existingJobId: job.id }
                     );
 
-                    if (!searchResult.found || searchResult.allMatches.length === 0) {
-                        await prisma.downloadJob.update({
-                            where: { id: job.id },
-                            data: {
-                                status: "failed",
-                                error: "No matching files found",
-                                completedAt: new Date(),
-                            },
-                        });
-                        continue;
-                    }
-
-                    const result = await soulseekService.downloadBestMatch(
-                        pendingTrack.spotifyArtist,
-                        pendingTrack.spotifyTitle,
-                        albumName,
-                        searchResult.allMatches,
-                        settings.musicPath
-                    );
-
-                    if (result.success) {
-                        await prisma.downloadJob.update({
-                            where: { id: job.id },
-                            data: {
-                                status: "completed",
-                                completedAt: new Date(),
-                                metadata: {
-                                    ...(job.metadata as any),
-                                    filePath: result.filePath,
-                                },
-                            },
-                        });
-
-                        try {
-                            const { scanQueue } = await import("../workers/queues");
-                            await scanQueue.add(
-                                "scan",
-                                {
-                                    userId,
-                                    source: "retry-pending-track-batch",
-                                    albumMbid: pendingTrack.albumMbid || undefined,
-                                    artistMbid: pendingTrack.artistMbid || undefined,
-                                },
-                                { priority: 1, removeOnComplete: true }
-                            );
-                        } catch (scanError) {
-                            logger.error(`[Retry-All] Failed to queue scan:`, scanError);
-                        }
-                    } else {
+                    // acquireAlbum + the Lidarr/Soulseek paths manage the job's
+                    // lifecycle (Lidarr completion arrives via webhook). Only
+                    // mark failed here if acquisition could not be started.
+                    if (!result.success) {
                         await prisma.downloadJob.update({
                             where: { id: job.id },
                             data: {
@@ -904,7 +858,7 @@ router.post("/:id/pending/retry-all", async (req, res) => {
                                 error: result.error || "Download failed",
                                 completedAt: new Date(),
                             },
-                        });
+                        }).catch(() => {});
                     }
                 } catch (error: any) {
                     logger.error(`[Retry-All] Error processing ${pendingTrack.spotifyTitle}:`, error);
@@ -912,7 +866,7 @@ router.post("/:id/pending/retry-all", async (req, res) => {
                         where: { id: job.id },
                         data: {
                             status: "failed",
-                            error: error?.message || "Download exception",
+                            error: error?.message || "Acquisition exception",
                             completedAt: new Date(),
                         },
                     }).catch(() => {});
@@ -1017,203 +971,72 @@ router.post("/:id/pending/:trackId/retry", async (req, res) => {
             `Created download job: downloadJobId=${downloadJob.id} target=${retryTargetId}`
         );
 
-        // Import soulseek service and try to download
-        const { soulseekService } = await import("../services/soulseek");
-        const { getSystemSettings } = await import("../utils/systemSettings");
+        // Route through the normal acquisition pipeline (respects the
+        // configured downloadSource: Lidarr or Soulseek) instead of hardcoding
+        // Soulseek. acquireAlbum reuses this job via existingJobId.
+        const { acquisitionService } = await import("../services/acquisitionService");
 
-        const settings = await getSystemSettings();
-        if (!settings?.musicPath) {
-            sessionLog("PENDING-RETRY", `Music path not configured`, "WARN");
-            await prisma.downloadJob.update({
-                where: { id: downloadJob.id },
-                data: {
-                    status: "failed",
-                    error: "Music path not configured",
-                    completedAt: new Date(),
-                },
-            });
-            return res.status(400).json({ error: "Music path not configured" });
-        }
-
-        if (!settings?.soulseekUsername || !settings?.soulseekPassword) {
-            sessionLog(
-                "PENDING-RETRY",
-                `Soulseek credentials not configured`,
-                "WARN"
-            );
-            await prisma.downloadJob.update({
-                where: { id: downloadJob.id },
-                data: {
-                    status: "failed",
-                    error: "Soulseek credentials not configured",
-                    completedAt: new Date(),
-                },
-            });
-            return res
-                .status(400)
-                .json({ error: "Soulseek credentials not configured" });
-        }
-
-        // Use a better album name if possible - extract from stored title or use artist name
         const albumName =
+            pendingTrack.spotifyAlbum &&
             pendingTrack.spotifyAlbum !== "Unknown Album"
                 ? pendingTrack.spotifyAlbum
-                : pendingTrack.spotifyArtist; // Use artist as fallback folder name
+                : pendingTrack.spotifyTitle;
 
-        logger.debug(
-            `[Retry] Starting download for: ${pendingTrack.spotifyArtist} - ${pendingTrack.spotifyTitle}`
-        );
         sessionLog(
             "PENDING-RETRY",
-            `Search: ${pendingTrack.spotifyArtist} - ${pendingTrack.spotifyTitle}`
+            `Queuing via acquisition pipeline: ${pendingTrack.spotifyArtist} - ${pendingTrack.spotifyTitle}`
         );
 
-        // First do a quick search to see if track is available (15s timeout)
-        // This way we can tell the user immediately if it's not found
-        const searchResult = await soulseekService.searchTrack(
-            pendingTrack.spotifyArtist,
-            pendingTrack.spotifyTitle,
-            pendingTrack.spotifyAlbum !== "Unknown Album" ? pendingTrack.spotifyAlbum : undefined
-        );
-
-        if (!searchResult.found || searchResult.allMatches.length === 0) {
-            logger.debug(`[Retry] No results found on Soulseek`);
-            sessionLog("PENDING-RETRY", `No results found on Soulseek`, "INFO");
-
-            await prisma.downloadJob.update({
-                where: { id: downloadJob.id },
-                data: {
-                    status: "failed",
-                    error: "No matching files found",
-                    completedAt: new Date(),
-                },
-            });
-
-            return res.status(200).json({
-                success: false,
-                message: "Track not found on Soulseek",
-                error: "No matching files found",
-            });
-        }
-
-        logger.debug(
-            `[Retry] ✓ Found ${searchResult.allMatches.length} results, starting download in background`
-        );
-        sessionLog(
-            "PENDING-RETRY",
-            `Found ${searchResult.allMatches.length} candidate(s); starting background download`
-        );
-
-        // Return immediately - download happens in background
+        // Respond immediately; acquisition runs in the background and updates the job.
         res.json({
             success: true,
             message: "Download started",
-            note: `Found ${searchResult.allMatches.length} sources. Downloading... Track will appear after scan.`,
+            note: "Queued via the configured download pipeline. Track will appear after import/scan.",
             downloadJobId: downloadJob.id,
         });
 
-        // Start download in background (don't await)
-        soulseekService
-            .downloadBestMatch(
-                pendingTrack.spotifyArtist,
-                pendingTrack.spotifyTitle,
-                albumName,
-                searchResult.allMatches,
-                settings.musicPath
+        acquisitionService
+            .acquireAlbum(
+                {
+                    albumTitle: albumName,
+                    artistName: pendingTrack.spotifyArtist,
+                    mbid: pendingTrack.albumMbid || undefined,
+                    artistMbid: pendingTrack.artistMbid || undefined,
+                },
+                { userId, existingJobId: downloadJob.id }
             )
             .then(async (result) => {
-                if (result.success) {
-                    logger.debug(
-                        `[Retry] ✓ Download complete: ${result.filePath}`
-                    );
+                if (!result.success) {
                     sessionLog(
                         "PENDING-RETRY",
-                        `Download complete: filePath=${result.filePath}`
-                    );
-
-                    await prisma.downloadJob.update({
-                        where: { id: downloadJob.id },
-                        data: {
-                            status: "completed",
-                            completedAt: new Date(),
-                            metadata: {
-                                ...(downloadJob.metadata as any),
-                                filePath: result.filePath,
-                            },
-                        },
-                    });
-
-                    // Trigger a library scan to add the track and reconcile pending
-                    try {
-                        const { scanQueue } = await import("../workers/queues");
-                        const scanJob = await scanQueue.add(
-                            "scan",
-                            {
-                                userId,
-                                source: "retry-pending-track",
-                                albumMbid: pendingTrack.albumMbid || undefined,
-                                artistMbid:
-                                    pendingTrack.artistMbid || undefined,
-                            },
-                            {
-                                priority: 1, // High priority
-                                removeOnComplete: true,
-                            }
-                        );
-                        logger.debug(
-                            `[Retry] Queued library scan to reconcile pending tracks`
-                        );
-                        sessionLog(
-                            "PENDING-RETRY",
-                            `Queued library scan (bullJobId=${
-                                scanJob.id ?? "unknown"
-                            })`
-                        );
-                    } catch (scanError) {
-                        logger.error(
-                            `[Retry] Failed to queue scan:`,
-                            scanError
-                        );
-                        sessionLog(
-                            "PENDING-RETRY",
-                            `Failed to queue scan: ${
-                                (scanError as any)?.message || scanError
-                            }`,
-                            "ERROR"
-                        );
-                    }
-                } else {
-                    logger.debug(`[Retry] Download failed: ${result.error}`);
-                    sessionLog(
-                        "PENDING-RETRY",
-                        `Download failed: ${result.error || "unknown error"}`,
+                        `Acquisition failed: ${result.error || "unknown error"}`,
                         "WARN"
                     );
-
-                    await prisma.downloadJob.update({
-                        where: { id: downloadJob.id },
-                        data: {
-                            status: "failed",
-                            error: result.error || "Download failed",
-                            completedAt: new Date(),
-                        },
-                    });
+                    await prisma.downloadJob
+                        .update({
+                            where: { id: downloadJob.id },
+                            data: {
+                                status: "failed",
+                                error: result.error || "Download failed",
+                                completedAt: new Date(),
+                            },
+                        })
+                        .catch(() => undefined);
+                } else {
+                    sessionLog(
+                        "PENDING-RETRY",
+                        `Acquisition started via ${result.source || "pipeline"}`
+                    );
                 }
             })
             .catch((error) => {
-                logger.error(`[Retry] Download error:`, error);
-                sessionLog(
-                    "PENDING-RETRY",
-                    `Download exception: ${error?.message || error}`,
-                    "ERROR"
-                );
-
+                logger.error(`[Retry] Acquisition error:`, error);
                 prisma.downloadJob
                     .update({
                         where: { id: downloadJob.id },
                         data: {
                             status: "failed",
-                            error: error?.message || "Download exception",
+                            error: error?.message || "Acquisition exception",
                             completedAt: new Date(),
                         },
                     })

--- a/backend/src/routes/releases.ts
+++ b/backend/src/routes/releases.ts
@@ -12,6 +12,7 @@ import { Router } from "express";
 import { lidarrService, CalendarRelease } from "../services/lidarr";
 import { prisma } from "../utils/db";
 import { requireAuthOrToken } from "../middleware/auth";
+import { acquisitionService } from "../services/acquisitionService";
 
 const router = Router();
 router.use(requireAuthOrToken);
@@ -236,12 +237,30 @@ router.post("/download/:albumMbid", async (req, res) => {
             return res.status(401).json({ error: "Authentication required" });
         }
 
-        logger.debug(`[Releases] Download requested for album: ${albumMbid}`);
+        const { artistName, title } = req.body || {};
 
-        // TODO: Implement downloadAlbum method on LidarrService
-        // For now, return not implemented error
-        res.status(501).json({
-            error: "Download feature not yet implemented for release radar"
+        if (!artistName || !title) {
+            return res.status(400).json({ error: "artistName and title are required in request body" });
+        }
+
+        logger.info(`[Releases] Download requested: ${artistName} - ${title} (${albumMbid})`);
+
+        res.json({ status: "downloading", albumMbid, title, artist: artistName });
+
+        acquisitionService.acquireAlbum({
+            albumTitle: title,
+            artistName,
+            mbid: albumMbid,
+        }, {
+            userId,
+        }).then(result => {
+            if (result.success) {
+                logger.info(`[Releases] Downloaded: ${artistName} - ${title}`);
+            } else {
+                logger.warn(`[Releases] Download failed: ${artistName} - ${title}: ${result.error}`);
+            }
+        }).catch(error => {
+            logger.error(`[Releases] Download error for ${albumMbid}:`, error);
         });
     } catch (error: any) {
         logger.error("[Releases] Download error:", error.message);

--- a/backend/src/services/acquisitionService.ts
+++ b/backend/src/services/acquisitionService.ts
@@ -42,6 +42,10 @@ export interface AlbumAcquisitionRequest {
     albumTitle: string;
     artistName: string;
     mbid?: string;
+    // Artist release-group MBID, when the caller already knows it (discovery /
+    // playlist pending tracks). Lets the Lidarr path skip a per-download
+    // MusicBrainz lookup that gets rate-limited in bursts.
+    artistMbid?: string;
     lastfmUrl?: string;
     requestedTracks?: Array<{ title: string; position?: number }>;
 }
@@ -775,7 +779,8 @@ class AcquisitionService {
                 request.albumTitle,
                 request.mbid,
                 context.userId,
-                isDiscovery
+                isDiscovery,
+                request.artistMbid
             );
 
             if (result.success) {

--- a/backend/src/services/discoverWeekly.ts
+++ b/backend/src/services/discoverWeekly.ts
@@ -339,6 +339,7 @@ export class DiscoverWeeklyService {
                             albumTitle: metadata.albumTitle,
                             artistName: metadata.artistName,
                             mbid: metadata.albumMbid,
+                            artistMbid: metadata.artistMbid,
                             lastfmUrl: undefined,
                         },
                         {

--- a/backend/src/services/lidarr.ts
+++ b/backend/src/services/lidarr.ts
@@ -900,6 +900,72 @@ class LidarrService {
         throw new Error(`Command ${commandId} timed out after ${timeoutMs}ms`);
     }
 
+    /**
+     * Add a specific album to Lidarr by its release-group MBID, via Lidarr's
+     * own album/lookup endpoint. Used as a fallback when the album isn't present
+     * in the artist's auto-populated catalog (compilations, obscure releases, or
+     * albums filtered out by the artist's metadata profile). This mirrors how
+     * Lidarr's UI adds a single album, so it enters the wanted list regardless of
+     * the catalog/metadata-profile state (Lidarr/Soularr then fulfill it).
+     */
+    private async addAlbumByLookup(
+        rgMbid: string,
+        artist: LidarrArtist,
+        rootFolderPath: string
+    ): Promise<LidarrAlbum | null> {
+        if (!this.client) return null;
+        try {
+            const lookup = await this.client.get("/api/v1/album/lookup", {
+                params: { term: `lidarr:${rgMbid}` },
+            });
+            const results: any[] = lookup.data || [];
+            const found = results.find((a) => a.foreignAlbumId === rgMbid) || null;
+            if (!found) {
+                logger.debug(`   [add-by-lookup] No Lidarr result for lidarr:${rgMbid}`);
+                return null;
+            }
+
+            // Already in Lidarr's library — hand back for the normal monitor/search path.
+            if (found.id && found.id > 0) {
+                logger.debug(`   [add-by-lookup] Album already in Lidarr (id=${found.id})`);
+                return found;
+            }
+
+            const validRootFolder = await this.ensureRootFolderExists(rootFolderPath);
+
+            const payload: any = {
+                ...found,
+                monitored: true,
+                profileId: this.qualityProfileId,
+                qualityProfileId: this.qualityProfileId,
+                addOptions: { searchForNewAlbum: true },
+                artist: {
+                    ...found.artist,
+                    id: artist.id,
+                    foreignArtistId:
+                        artist.foreignArtistId || found.artist?.foreignArtistId,
+                    qualityProfileId: this.qualityProfileId,
+                    metadataProfileId: this.metadataProfileId,
+                    rootFolderPath: validRootFolder,
+                    monitored: true,
+                    monitorNewItems: "none",
+                    addOptions: { monitor: "none", searchForMissingAlbums: false },
+                },
+            };
+
+            const resp = await this.client.post("/api/v1/album", payload);
+            logger.debug(`   [add-by-lookup] Added "${found.title}" (id=${resp.data?.id})`);
+            return resp.data;
+        } catch (err: any) {
+            logger.warn(
+                `   [add-by-lookup] failed: ${
+                    err.response?.data?.[0]?.errorMessage || err.message
+                }`
+            );
+            return null;
+        }
+    }
+
     async addAlbum(
         rgMbid: string,
         artistName: string,
@@ -1146,6 +1212,23 @@ class LidarrService {
                 } else {
                     logger.debug(
                         ` No strict match found - will NOT use loose matching to avoid wrong albums`
+                    );
+                }
+            }
+
+            // Fallback: the album isn't in the artist's auto-populated catalog
+            // (compilation / obscure release / metadata-profile filtered). Add it
+            // directly via Lidarr's MBID lookup so it still enters the wanted list.
+            if (!albumData) {
+                logger.debug(
+                    `   Album not in artist catalog — trying direct Lidarr MBID-lookup add...`
+                );
+                albumData =
+                    (await this.addAlbumByLookup(rgMbid, artist, rootFolderPath)) ??
+                    undefined;
+                if (albumData) {
+                    logger.debug(
+                        `   [add-by-lookup] success: "${albumData.title}" (id=${albumData.id})`
                     );
                 }
             }

--- a/backend/src/services/rateLimiter.ts
+++ b/backend/src/services/rateLimiter.ts
@@ -249,7 +249,10 @@ class GlobalRateLimiter {
         if (retryAfter) {
             const parsed = parseInt(retryAfter, 10);
             if (!isNaN(parsed)) {
-                return parsed * 1000; // Convert to ms
+                // Honor Retry-After, but never back off below baseDelay — some
+                // endpoints/proxies return 0 (or a tiny value), which would
+                // otherwise hot-loop the retries and exhaust them instantly.
+                return Math.max(parsed * 1000, baseDelay);
             }
         }
 

--- a/backend/src/services/simpleDownloadManager.ts
+++ b/backend/src/services/simpleDownloadManager.ts
@@ -134,7 +134,8 @@ class SimpleDownloadManager {
         albumTitle: string,
         albumMbid: string,
         userId: string,
-        isDiscovery: boolean = false
+        isDiscovery: boolean = false,
+        providedArtistMbid?: string
     ): Promise<{ success: boolean; correlationId?: string; error?: string; errorType?: AcquisitionErrorType; isRecoverable?: boolean }> {
         logger.debug(
             `\n Starting download: ${artistName} - ${albumTitle}${
@@ -152,27 +153,38 @@ class SimpleDownloadManager {
             const settings = await getSystemSettings();
             const musicPath = settings?.musicPath || config.music.musicPath;
 
-            // Fetch artist MBID from MusicBrainz using the album MBID
-            let artistMbid: string | undefined;
-            try {
-                logger.debug(`   Fetching artist MBID from MusicBrainz...`);
-                const releaseGroup = await musicBrainzService.getReleaseGroup(
-                    albumMbid
-                );
+            // Resolve the artist MBID. Prefer a value the caller already has
+            // (discovery and playlist pending tracks store it) so we don't make
+            // a per-download MusicBrainz call — those get rate-limited in bursts
+            // (shared VPN exit IP) and the whole add then fails "album not found".
+            // Fall back to a MusicBrainz lookup only when it's unknown.
+            let artistMbid: string | undefined =
+                providedArtistMbid && !providedArtistMbid.startsWith("temp-")
+                    ? providedArtistMbid
+                    : undefined;
+            if (artistMbid) {
+                logger.debug(`   Using caller-provided artist MBID: ${artistMbid}`);
+            } else {
+                try {
+                    logger.debug(`   Fetching artist MBID from MusicBrainz...`);
+                    const releaseGroup = await musicBrainzService.getReleaseGroup(
+                        albumMbid
+                    );
 
-                if (releaseGroup?.["artist-credit"]?.[0]?.artist?.id) {
-                    artistMbid = releaseGroup["artist-credit"][0].artist.id;
-                    logger.debug(`   Found artist MBID: ${artistMbid}`);
-                } else {
-                    logger.warn(
-                        `   Could not extract artist MBID from release group`
+                    if (releaseGroup?.["artist-credit"]?.[0]?.artist?.id) {
+                        artistMbid = releaseGroup["artist-credit"][0].artist.id;
+                        logger.debug(`   Found artist MBID: ${artistMbid}`);
+                    } else {
+                        logger.warn(
+                            `   Could not extract artist MBID from release group`
+                        );
+                    }
+                } catch (mbError) {
+                    logger.error(
+                        `   Failed to fetch artist MBID from MusicBrainz:`,
+                        mbError
                     );
                 }
-            } catch (mbError) {
-                logger.error(
-                    `   Failed to fetch artist MBID from MusicBrainz:`,
-                    mbError
-                );
             }
 
             // Add album to Lidarr (with discovery tag if this is a discovery download)

--- a/backend/src/services/soulseek.ts
+++ b/backend/src/services/soulseek.ts
@@ -1706,7 +1706,28 @@ async searchAndDownloadAlbum(
 
             const slotsBonus = files.some(f => f.slots) ? 10 : 0;
             const speedBonus = Math.min(files[0]?.speed || 0, 10000000) / 1000000;
-            const totalScore = matchRatio * 100 + qualityBonus + slotsBonus + speedBonus;
+
+            // Edition preference scoring — penalize bloated/deluxe releases,
+            // reward groups whose file count closely matches the expected track count.
+            const fileCountRatio = files.length / Math.max(tracks.length, 1);
+            const bloatPenalty = fileCountRatio > 1.5
+                ? Math.min((fileCountRatio - 1) * 20, 40)
+                : 0;
+            const dirPath = key.split("|||")[1] || "";
+            const dirLower = dirPath.toLowerCase();
+            const editionPattern = /(?:deluxe|super.deluxe|anniversary|box.set|collector|expanded|remaster|limited|platinum|explicit|japan|bonus|special.edition)/;
+            const editionPenalty = editionPattern.test(dirLower) ? 25 : 0;
+            const sizeMatchBonus = (fileCountRatio >= 0.8 && fileCountRatio <= 1.3) ? 15 : 0;
+            if (bloatPenalty > 0 || editionPenalty > 0) {
+                sessionLog(
+                    "SOULSEEK",
+                    `[Album Search] Group ${key.split("|||")[0]}: ${files.length} files/${tracks.length} tracks ` +
+                    `(ratio ${fileCountRatio.toFixed(1)}x) bloat=-${bloatPenalty.toFixed(0)} edition=-${editionPenalty} sizeMatch=+${sizeMatchBonus}`,
+                    "DEBUG"
+                );
+            }
+
+            const totalScore = matchRatio * 100 + qualityBonus + slotsBonus + speedBonus + sizeMatchBonus - bloatPenalty - editionPenalty;
 
             scoredGroups.push({
                 key,

--- a/backend/src/services/soulseek.ts
+++ b/backend/src/services/soulseek.ts
@@ -1696,12 +1696,21 @@ async searchAndDownloadAlbum(
                 .map((_, i) => i)
                 .filter(i => !matchedTracks.has(i));
 
+            // Quality is a PER-CANDIDATE signal (average format score), not a
+            // per-file sum: summing rewarded large file counts, so a deluxe
+            // FLAC set scored so high it swamped the edition/bloat penalties
+            // below and always beat the original edition. Averaging keeps this
+            // bounded (~0..3) regardless of track count.
             let qualityBonus = 0;
-            for (const f of files) {
-                const lower = f.file.toLowerCase();
-                if (lower.endsWith(".flac")) qualityBonus += 3;
-                else if (lower.endsWith(".mp3") && (f.bitrate || 0) >= 320) qualityBonus += 2;
-                else if (lower.endsWith(".mp3") && (f.bitrate || 0) >= 256) qualityBonus += 1;
+            if (files.length > 0) {
+                let qualitySum = 0;
+                for (const f of files) {
+                    const lower = f.file.toLowerCase();
+                    if (lower.endsWith(".flac")) qualitySum += 3;
+                    else if (lower.endsWith(".mp3") && (f.bitrate || 0) >= 320) qualitySum += 2;
+                    else if (lower.endsWith(".mp3") && (f.bitrate || 0) >= 256) qualitySum += 1;
+                }
+                qualityBonus = qualitySum / files.length;
             }
 
             const slotsBonus = files.some(f => f.slots) ? 10 : 0;
@@ -1715,7 +1724,9 @@ async searchAndDownloadAlbum(
                 : 0;
             const dirPath = key.split("|||")[1] || "";
             const dirLower = dirPath.toLowerCase();
-            const editionPattern = /(?:deluxe|super.deluxe|anniversary|box.set|collector|expanded|remaster|limited|platinum|explicit|japan|bonus|special.edition)/;
+            // Word-bounded so the separator dots are literal and terms like
+            // "limited"/"explicit"/"japan" don't match inside longer words.
+            const editionPattern = /\b(?:deluxe|super[\s._-]?deluxe|anniversary|box[\s._-]?set|collector|expanded|remaster|limited|platinum|explicit|japan|bonus|special[\s._-]?edition)\b/;
             const editionPenalty = editionPattern.test(dirLower) ? 25 : 0;
             const sizeMatchBonus = (fileCountRatio >= 0.8 && fileCountRatio <= 1.3) ? 15 : 0;
             if (bloatPenalty > 0 || editionPenalty > 0) {

--- a/frontend/app/releases/page.tsx
+++ b/frontend/app/releases/page.tsx
@@ -51,10 +51,10 @@ export default function ReleasesPage() {
         fetchReleases();
     }, []);
 
-    const handleDownload = async (albumMbid: string, releaseId: string | number) => {
+    const handleDownload = async (albumMbid: string, releaseId: string | number, artistName: string, title: string) => {
         try {
             setDownloadingId(releaseId);
-            await api.post(`/releases/download/${albumMbid}`);
+            await api.post(`/releases/download/${albumMbid}`, { artistName, title });
             await fetchReleases();
         } catch (err) {
             console.error("Download failed:", err);
@@ -200,7 +200,7 @@ function ReleaseCard({
 }: {
     release: ReleaseItem;
     formatDate: (date: string) => string;
-    onDownload: (albumMbid: string, releaseId: string | number) => void;
+    onDownload: (albumMbid: string, releaseId: string | number, artistName: string, title: string) => void;
     isDownloading: boolean;
 }) {
     const isUpcoming = release.status === 'upcoming';
@@ -238,7 +238,7 @@ function ReleaseCard({
                 {/* Download Button Overlay */}
                 {release.canDownload && !hasIt && (
                     <button
-                        onClick={() => onDownload(release.albumMbid, release.id)}
+                        onClick={() => onDownload(release.albumMbid, release.id, release.artistName, release.title)}
                         disabled={isDownloading}
                         className={cn(
                             "absolute inset-0 flex items-center justify-center",


### PR DESCRIPTION
## Description

A small batch of independent Lidarr / Soulseek / discovery fixes and improvements. Each is small, so they're grouped into one PR — happy to split if you'd rather review them separately.

## Type of Change

-   [x] Bug fix (non-breaking change that fixes an issue)
-   [x] Enhancement (improvement to existing functionality)

## Changes Made

-   **lidarr:** reuse a known artist MBID instead of doing a per-download MusicBrainz lookup (threads an optional `artistMbid` through request → acquisition → download manager), cutting redundant MB calls. Includes a small, logically independent `rateLimiter` tweak (`Math.max(parsed * 1000, baseDelay)`).
-   **lidarr:** add albums via MBID lookup when the release isn't in the artist's catalog.
-   **downloads:** optionally fall back to Soulseek when Lidarr is unavailable, gated by `DOWNLOAD_SOULSEEK_AUTO_FALLBACK` (defaults **off**; documented in `.env.example`).
-   **playlists:** allow admins to retry pending downloads on any playlist — an admin-role bypass on top of the existing owner check (non-admin non-owners still get 403).
-   **artists:** resolve an owned artist in the discovery route and 307-redirect to the canonical library page, to avoid duplicate artist pages. The route param is decoded defensively so a name containing a literal `%` (e.g. "50%") doesn't error.
-   **soulseek:** prefer original album editions in album-search scoring — penalise bloated/deluxe releases and reward a close file-count match. Quality is scored per-candidate rather than per-file, so a large deluxe set can't win on file count alone.
-   **releases:** implement release-radar download via the acquisition service.

## Testing Done

-   [x] Tested locally with Docker
-   [x] Running on my deployment

## Notes

-   Release-radar download still passes only `artistName` (not the known artist MBID), so it doesn't yet benefit from the per-download MBID optimisation above — easy follow-up if wanted.
-   The edition-scoring heuristic is string-based and imperfect (e.g. a band literally named "Japan"); the word boundaries reduce but don't eliminate false positives.

## Checklist

-   [x] My code follows the project's code style
-   [x] I have tested my changes locally
-   [x] I have updated documentation if needed
-   [x] My changes don't introduce new warnings
-   [x] This PR targets the `main` branch

