### PR TITLE
feat(auth): admin user management — reset passwords, edit username & role

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -375,6 +375,155 @@ router.delete("/users/:id", requireAuth, requireAdmin, async (req, res) => {
     }
 });
 
+// POST /auth/users/:id/reset-password (Admin only)
+// Set another user's password without knowing their current one. Increments
+// tokenVersion so the target user's existing sessions are invalidated.
+router.post(
+    "/users/:id/reset-password",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+        try {
+            const { id } = req.params;
+            const { newPassword } = req.body;
+
+            if (!newPassword || typeof newPassword !== "string") {
+                return res.status(400).json({ error: "New password is required" });
+            }
+
+            if (newPassword.length < 6) {
+                return res
+                    .status(400)
+                    .json({ error: "New password must be at least 6 characters" });
+            }
+
+            const target = await prisma.user.findUnique({
+                where: { id },
+                select: { id: true, username: true },
+            });
+
+            if (!target) {
+                return res.status(404).json({ error: "User not found" });
+            }
+
+            const passwordHash = await bcrypt.hash(newPassword, 10);
+            await prisma.user.update({
+                where: { id },
+                data: {
+                    passwordHash,
+                    tokenVersion: { increment: 1 },
+                },
+            });
+
+            logger.info(
+                `[AUTH] Admin ${req.user!.id} reset password for user ${target.username} (${id})`
+            );
+            res.json({ message: "Password reset successfully" });
+        } catch (error: any) {
+            logger.error("Admin reset password error:", error);
+            if (error.code === "P2025") {
+                return res.status(404).json({ error: "User not found" });
+            }
+            res.status(500).json({ error: "Failed to reset password" });
+        }
+    }
+);
+
+// PATCH /auth/users/:id (Admin only) — edit a user's username and/or role.
+// Role/username are read fresh from the DB on every request, so changes take
+// effect immediately without invalidating sessions. Guards against demoting
+// the last remaining admin (which would lock everyone out of admin functions).
+router.patch("/users/:id", requireAuth, requireAdmin, async (req, res) => {
+    try {
+        const { id } = req.params;
+        const { username, role } = req.body as {
+            username?: string;
+            role?: string;
+        };
+
+        if (username === undefined && role === undefined) {
+            return res
+                .status(400)
+                .json({ error: "Provide a username and/or role to update" });
+        }
+
+        const target = await prisma.user.findUnique({
+            where: { id },
+            select: { id: true, username: true, role: true },
+        });
+        if (!target) {
+            return res.status(404).json({ error: "User not found" });
+        }
+
+        const data: { username?: string; role?: string } = {};
+
+        if (username !== undefined) {
+            const trimmed = String(username).trim();
+            if (!trimmed) {
+                return res.status(400).json({ error: "Username cannot be empty" });
+            }
+            if (trimmed !== target.username) {
+                const clash = await prisma.user.findUnique({
+                    where: { username: trimmed },
+                    select: { id: true },
+                });
+                if (clash && clash.id !== id) {
+                    return res.status(400).json({ error: "Username already taken" });
+                }
+                data.username = trimmed;
+            }
+        }
+
+        if (role !== undefined) {
+            if (!["user", "admin"].includes(role)) {
+                return res.status(400).json({ error: "Invalid role" });
+            }
+            // Block demoting the last admin (lockout protection).
+            if (target.role === "admin" && role !== "admin") {
+                const adminCount = await prisma.user.count({
+                    where: { role: "admin" },
+                });
+                if (adminCount <= 1) {
+                    return res
+                        .status(400)
+                        .json({ error: "Cannot demote the last admin" });
+                }
+            }
+            if (role !== target.role) {
+                data.role = role;
+            }
+        }
+
+        if (Object.keys(data).length === 0) {
+            return res.json({
+                id: target.id,
+                username: target.username,
+                role: target.role,
+            });
+        }
+
+        const updated = await prisma.user.update({
+            where: { id },
+            data,
+            select: { id: true, username: true, role: true },
+        });
+
+        logger.info(
+            `[AUTH] Admin ${req.user!.id} updated user ${id}: ${JSON.stringify(data)}`
+        );
+        res.json(updated);
+    } catch (error: any) {
+        logger.error("Admin update user error:", error);
+        if (error.code === "P2002") {
+            return res.status(400).json({ error: "Username already taken" });
+        }
+        if (error.code === "P2025") {
+            return res.status(404).json({ error: "User not found" });
+        }
+        res.status(500).json({ error: "Failed to update user" });
+    }
+});
+
 // POST /auth/2fa/setup - Generate 2FA secret and QR code
 router.post("/2fa/setup", requireAuth, async (req, res) => {
     try {

--- a/frontend/features/settings/components/sections/UserManagementSection.tsx
+++ b/frontend/features/settings/components/sections/UserManagementSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2, KeyRound, Pencil } from "lucide-react";
 import { SettingsSection, SettingsInput, SettingsSelect } from "../ui";
 import { Modal } from "@/components/ui/Modal";
 import { useAuth } from "@/lib/auth-context";
@@ -28,6 +28,15 @@ export function UserManagementSection() {
     const [createMessage, setCreateMessage] = useState("");
     const [deleteStatus, setDeleteStatus] = useState<StatusType>("idle");
     const [deleteMessage, setDeleteMessage] = useState("");
+    const [resetTarget, setResetTarget] = useState<User | null>(null);
+    const [resetPassword, setResetPassword] = useState("");
+    const [resetStatus, setResetStatus] = useState<StatusType>("idle");
+    const [resetMessage, setResetMessage] = useState("");
+    const [editTarget, setEditTarget] = useState<User | null>(null);
+    const [editUsername, setEditUsername] = useState("");
+    const [editRole, setEditRole] = useState<"user" | "admin">("user");
+    const [editStatus, setEditStatus] = useState<StatusType>("idle");
+    const [editMessage, setEditMessage] = useState("");
 
     useEffect(() => {
         loadUsers();
@@ -71,6 +80,71 @@ export function UserManagementSection() {
             setCreateMessage(error instanceof Error ? error.message : "Failed");
         } finally {
             setCreating(false);
+        }
+    };
+
+    const openReset = (user: User) => {
+        setResetTarget(user);
+        setResetPassword("");
+        setResetStatus("idle");
+        setResetMessage("");
+    };
+
+    const handleResetPassword = async () => {
+        if (!resetTarget || resetPassword.length < 6) {
+            setResetStatus("error");
+            setResetMessage("Password 6+ chars");
+            return;
+        }
+        setResetStatus("loading");
+        try {
+            await api.post(`/auth/users/${resetTarget.id}/reset-password`, {
+                newPassword: resetPassword,
+            });
+            setResetStatus("success");
+            setResetMessage("Password reset");
+            setResetPassword("");
+            // brief pause so the success state is visible before closing
+            setTimeout(() => setResetTarget(null), 800);
+        } catch (error: unknown) {
+            setResetStatus("error");
+            setResetMessage(error instanceof Error ? error.message : "Failed");
+        }
+    };
+
+    const openEdit = (user: User) => {
+        setEditTarget(user);
+        setEditUsername(user.username);
+        setEditRole(user.role);
+        setEditStatus("idle");
+        setEditMessage("");
+    };
+
+    const handleEdit = async () => {
+        if (!editTarget) return;
+        const trimmed = editUsername.trim();
+        if (!trimmed) {
+            setEditStatus("error");
+            setEditMessage("Username required");
+            return;
+        }
+        if (trimmed === editTarget.username && editRole === editTarget.role) {
+            setEditTarget(null);
+            return;
+        }
+        setEditStatus("loading");
+        try {
+            await api.patch(`/auth/users/${editTarget.id}`, {
+                username: trimmed,
+                role: editRole,
+            });
+            setEditStatus("success");
+            setEditMessage("Saved");
+            setTimeout(() => setEditTarget(null), 800);
+            loadUsers();
+        } catch (error: unknown) {
+            setEditStatus("error");
+            setEditMessage(error instanceof Error ? error.message : "Failed");
         }
     };
 
@@ -174,14 +248,31 @@ export function UserManagementSection() {
                                     </div>
                                 </div>
 
-                                {currentUser?.id !== user.id && (
+                                <div className="flex items-center gap-1">
                                     <button
-                                        onClick={() => setConfirmDelete(user.id)}
-                                        className="p-2 text-white/20 hover:text-red-400 transition-colors"
+                                        onClick={() => openEdit(user)}
+                                        title="Edit username / role"
+                                        className="p-2 text-white/20 hover:text-white transition-colors"
                                     >
-                                        <Trash2 className="w-4 h-4" />
+                                        <Pencil className="w-4 h-4" />
                                     </button>
-                                )}
+                                    <button
+                                        onClick={() => openReset(user)}
+                                        title="Reset password"
+                                        className="p-2 text-white/20 hover:text-brand transition-colors"
+                                    >
+                                        <KeyRound className="w-4 h-4" />
+                                    </button>
+                                    {currentUser?.id !== user.id && (
+                                        <button
+                                            onClick={() => setConfirmDelete(user.id)}
+                                            title="Delete user"
+                                            className="p-2 text-white/20 hover:text-red-400 transition-colors"
+                                        >
+                                            <Trash2 className="w-4 h-4" />
+                                        </button>
+                                    )}
+                                </div>
                             </div>
                         ))
                     )}
@@ -215,6 +306,111 @@ export function UserManagementSection() {
                             className="px-4 py-2 text-xs font-black bg-red-500 text-white rounded-lg uppercase tracking-wider hover:bg-red-600 transition-colors"
                         >
                             Delete
+                        </button>
+                    </div>
+                </div>
+            </Modal>
+
+            {/* Reset Password Modal */}
+            <Modal
+                isOpen={!!resetTarget}
+                onClose={() => setResetTarget(null)}
+                title={`Reset Password${resetTarget ? ` — ${resetTarget.username}` : ""}`}
+            >
+                <div className="space-y-4">
+                    <p className="text-xs font-mono text-white/50 uppercase tracking-wider">
+                        Set a new password for this user. Their existing sessions will be
+                        signed out.
+                        {resetTarget && currentUser?.id === resetTarget.id && (
+                            <span className="block mt-2 text-amber-400/70">
+                                This is your own account — you&apos;ll be logged out.
+                            </span>
+                        )}
+                    </p>
+                    <SettingsInput
+                        type="password"
+                        value={resetPassword}
+                        onChange={setResetPassword}
+                        placeholder="New password (6+ chars)"
+                        className="w-full"
+                    />
+                    <div className="flex gap-2 justify-end items-center">
+                        <InlineStatus
+                            status={resetStatus}
+                            message={resetMessage}
+                            onClear={() => setResetStatus("idle")}
+                        />
+                        <button
+                            onClick={() => setResetTarget(null)}
+                            className="px-4 py-2 text-xs font-mono text-white/40 hover:text-white/70 uppercase tracking-wider transition-colors"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            onClick={handleResetPassword}
+                            disabled={resetStatus === "loading" || resetPassword.length < 6}
+                            className="px-4 py-2 text-xs font-black bg-brand text-black rounded-lg uppercase tracking-wider hover:bg-[#f97316] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                            {resetStatus === "loading" ? "Resetting..." : "Reset Password"}
+                        </button>
+                    </div>
+                </div>
+            </Modal>
+
+            {/* Edit User Modal */}
+            <Modal
+                isOpen={!!editTarget}
+                onClose={() => setEditTarget(null)}
+                title={`Edit User${editTarget ? ` — ${editTarget.username}` : ""}`}
+            >
+                <div className="space-y-4">
+                    <div>
+                        <label className="block text-[10px] font-mono text-white/40 mb-1 uppercase tracking-wider">
+                            Username
+                        </label>
+                        <SettingsInput
+                            value={editUsername}
+                            onChange={setEditUsername}
+                            placeholder="Username"
+                            className="w-full"
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-[10px] font-mono text-white/40 mb-1 uppercase tracking-wider">
+                            Role
+                        </label>
+                        <SettingsSelect
+                            value={editRole}
+                            onChange={(v) => setEditRole(v as "user" | "admin")}
+                            options={[
+                                { value: "user", label: "User" },
+                                { value: "admin", label: "Admin" },
+                            ]}
+                        />
+                    </div>
+                    {editTarget && currentUser?.id === editTarget.id && editRole !== "admin" && (
+                        <p className="text-xs font-mono text-amber-400/70 uppercase tracking-wider">
+                            ⚠ Demoting yourself will remove your admin access.
+                        </p>
+                    )}
+                    <div className="flex gap-2 justify-end items-center">
+                        <InlineStatus
+                            status={editStatus}
+                            message={editMessage}
+                            onClear={() => setEditStatus("idle")}
+                        />
+                        <button
+                            onClick={() => setEditTarget(null)}
+                            className="px-4 py-2 text-xs font-mono text-white/40 hover:text-white/70 uppercase tracking-wider transition-colors"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            onClick={handleEdit}
+                            disabled={editStatus === "loading" || !editUsername.trim()}
+                            className="px-4 py-2 text-xs font-black bg-brand text-black rounded-lg uppercase tracking-wider hover:bg-[#f97316] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                            {editStatus === "loading" ? "Saving..." : "Save"}
                         </button>
                     </div>
                 </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -322,6 +322,14 @@ class ApiClient {
         });
     }
 
+    // Generic PATCH method for convenience
+    async patch<T = unknown>(endpoint: string, data?: unknown): Promise<T> {
+        return this.request<T>(endpoint, {
+            method: "PATCH",
+            body: data ? JSON.stringify(data) : undefined,
+        });
+    }
+
     // Auth
     async login(username: string, password: string, token?: string): Promise<{
         id: string;


### PR DESCRIPTION
## Description

Adds admin-only user management to the User Management settings section: reset another user's password, and edit a user's username and/or role. Previously admins could only create and delete users.

## Type of Change

-   [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #

## Changes Made

- `POST /auth/users/:id/reset-password` (admin) — set another user's password without their current one; bumps `tokenVersion` to invalidate that user's existing sessions.
- `PATCH /auth/users/:id` (admin) — change a user's username and/or role. Role and username are read from the DB per request, so changes take effect immediately without a re-login. Guards: username uniqueness, valid role, and refuses to demote the last remaining admin (lockout protection).
- UI: pencil (edit username/role) and key (reset password) actions per user, each with a confirmation modal. Adds a generic `api.patch` helper.

## Testing Done

-   [x] Tested locally with Docker
-   [x] Tested specific functionality: password reset (target sessions invalidated), username/role edit (applies without re-login), last-admin demotion blocked, username-collision rejected.

## Checklist

-   [x] My code follows the project's code style
-   [x] I have tested my changes locally
-   [ ] I have updated documentation if needed
-   [x] My changes don't introduce new warnings
-   [x] This PR targets the `main` branch