### PR TITLE
fix: slskd key decrypt, BigInt SSE, IPv4 axios, podcast infinite spinner

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -50,3 +50,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,52 @@
+name: Build & push image (ghcr)
+
+on:
+  push:
+    branches: [fix/ipv4-slskd-bigint, main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker image prune -af || true
+          df -h
+
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=1.8.1-fix
+            type=ref,event=branch
+            type=sha,format=short
+
+      - name: Build & push (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,23 @@ import { config } from "./config";
 import { redisClient } from "./utils/redis";
 import { prisma } from "./utils/db";
 import { logger } from "./utils/logger";
+import http from "http";
+import https from "https";
+import axios from "axios";
+
+// I messaggi Soulseek usano BigInt per size/byte-counter. JSON.stringify non sa
+// serializzare i BigInt e lancia "Do not know how to serialize a BigInt"
+// (es. nello stream SSE di routes/events.ts). Esponiamo i BigInt come Number
+// (i size dei file sono ben sotto Number.MAX_SAFE_INTEGER).
+(BigInt.prototype as unknown as { toJSON: () => number }).toJSON = function () {
+    return Number(this as unknown as bigint);
+};
+
+// Forza IPv4 su tutte le chiamate axios: in pod senza IPv6 in uscita, gli host
+// con record AAAA (itunes.apple.com, feed podcast, deezer...) facevano appendere
+// la connessione su IPv6 fino al timeout (spinner podcast). Default globale axios.
+axios.defaults.httpAgent = new http.Agent({ family: 4, keepAlive: true });
+axios.defaults.httpsAgent = new https.Agent({ family: 4, keepAlive: true });
 
 import authRoutes from "./routes/auth";
 import onboardingRoutes from "./routes/onboarding";

--- a/backend/src/utils/systemSettings.ts
+++ b/backend/src/utils/systemSettings.ts
@@ -71,6 +71,7 @@ export async function getSystemSettings(forceRefresh = false) {
             settings.audiobookshelfApiKey,
             "audiobookshelfApiKey",
         ),
+        slskdApiKey: safeDecrypt(settings.slskdApiKey, "slskdApiKey"),
         soulseekPassword: safeDecrypt(
             settings.soulseekPassword,
             "soulseekPassword",

--- a/frontend/features/podcast/hooks/usePodcastData.ts
+++ b/frontend/features/podcast/hooks/usePodcastData.ts
@@ -107,7 +107,11 @@ export function usePodcastData() {
 
     loadPreviewData();
     return () => { cancelled = true; };
-  }, [isPodcastLoading, podcast, isAuthenticated, podcastId, router, previewLoadState]);
+    // NB: previewLoadState NON va nelle deps: settando 'loading' dentro l'effect
+    // farebbe ri-eseguire l'effect, la cleanup annulla il load in volo (cancelled=true)
+    // e non si arriva mai a 'done' -> spinner infinito. La guardia interna basta.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPodcastLoading, podcast, isAuthenticated, podcastId, router]);
 
   // Save sort order to localStorage when it changes
   useEffect(() => {


### PR DESCRIPTION
### Summary
Four fixes found running Kima in Kubernetes (containers without working outbound IPv6).

**1. slskd REST: API key sent encrypted** — `getSystemSettings()` (backend/src/utils/systemSettings.ts) decrypts lidarrApiKey/audiobookshelfApiKey/soulseekPassword but not `slskdApiKey`, so the raw `iv:ciphertext` was sent as `X-API-Key` → slskd "Unknown API key". Fix: `slskdApiKey: safeDecrypt(...)`.

**2. SSE crash "Do not know how to serialize a BigInt"** — Soulseek size/byte fields are BigInt; the SSE serializer (routes/events.ts) `JSON.stringify` has no BigInt replacer. Fix: global `BigInt.prototype.toJSON` in index.ts.

**3. Outbound axios hangs on IPv6** — hosts with AAAA records (itunes.apple.com, podcast feeds, Deezer, Last.fm…) hang until timeout where outbound IPv6 is broken → podcast preview spinner + general slowness. Fix: IPv4 agents as global axios defaults (`family: 4`) in index.ts.

**4. Podcast detail page: infinite loading spinner** — `frontend/features/podcast/hooks/usePodcastData.ts`: the preview `useEffect` had `previewLoadState` in its dependency array. Setting it to `'loading'` re-triggered the effect; the cleanup set `cancelled = true` on the in-flight request, so it never reached `'done'` → infinite spinner on every podcast page (backend preview returns fine). Fix: remove `previewLoadState` from the deps.

### Changes
- backend/src/utils/systemSettings.ts — decrypt slskdApiKey
- backend/src/index.ts — BigInt.prototype.toJSON + axios IPv4 default agents
- frontend/features/podcast/hooks/usePodcastData.ts — fix preview useEffect deps (infinite spinner)

### Testing
Built and deployed in a live Kubernetes cluster: slskd auth OK, no BigInt SSE crash, itunes/feed fetched over IPv4, and podcast episode lists now load (were stuck on an infinite spinner).
