### PR TITLE
fix(analyzer): reap timed-out process pool workers

### DIFF
--- a/services/audio-analyzer/analyzer.py
+++ b/services/audio-analyzer/analyzer.py
@@ -132,6 +132,65 @@ MODEL_IDLE_TIMEOUT = int(os.getenv('MODEL_IDLE_TIMEOUT', '300'))
 # Debounce delay for worker resize (seconds) -- prevents pool churn when user drags a slider
 RESIZE_DEBOUNCE_SECONDS = 5
 
+# Forced teardown is reserved for timeout/recovery paths. Bounded waits keep a
+# wedged native TensorFlow/Essentia worker from hanging recovery indefinitely.
+PROCESS_TERMINATE_WAIT_SECONDS = 2
+PROCESS_KILL_WAIT_SECONDS = 1
+
+
+def _force_shutdown_executor(executor):
+    """Cancel pending work and forcibly reap an executor's live processes.
+
+    ProcessPoolExecutor has no public API for terminating running work. The
+    CPython-specific process snapshot is guarded so other implementations can
+    still cancel queued work and request nonblocking shutdown safely.
+    """
+    if executor is None:
+        return
+
+    processes = []
+    executor_processes = getattr(executor, '_processes', None)
+    if executor_processes is not None:
+        try:
+            processes = list(executor_processes.values())
+        except (AttributeError, RuntimeError):
+            logger.warning("Could not snapshot process pool workers for forced teardown")
+
+    try:
+        executor.shutdown(wait=False, cancel_futures=True)
+    except TypeError:
+        # cancel_futures was added in Python 3.9.
+        try:
+            executor.shutdown(wait=False)
+        except Exception as e:
+            logger.warning(f"Error requesting compatible executor shutdown: {e}")
+    except Exception as e:
+        logger.warning(f"Error requesting executor shutdown: {e}")
+
+    for process in processes:
+        try:
+            if process.is_alive():
+                process.terminate()
+        except Exception as e:
+            logger.warning(f"Error terminating pool worker: {e}")
+
+    for process in processes:
+        try:
+            process.join(timeout=PROCESS_TERMINATE_WAIT_SECONDS)
+        except Exception as e:
+            logger.warning(f"Error joining terminated pool worker: {e}")
+
+    for process in processes:
+        try:
+            if process.is_alive():
+                logger.warning(f"Pool worker {process.pid} did not terminate; killing it")
+                process.kill()
+                process.join(timeout=PROCESS_KILL_WAIT_SECONDS)
+        except (AttributeError, NotImplementedError):
+            logger.warning("Pool worker survived termination but kill is unavailable")
+        except Exception as e:
+            logger.warning(f"Error killing pool worker: {e}")
+
 
 class DatabaseConnection:
     """PostgreSQL connection manager"""
@@ -1302,10 +1361,7 @@ class AnalysisWorker:
             return
         if self.executor is not None:
             # Stale executor reference, clean it up
-            try:
-                self.executor.shutdown(wait=False)
-            except Exception:
-                pass
+            self._force_shutdown_pool()
         logger.info(f"Starting worker pool with {NUM_WORKERS} processes...")
         self.executor = ProcessPoolExecutor(
             max_workers=NUM_WORKERS,
@@ -1329,7 +1385,7 @@ class AnalysisWorker:
         # Also shut down scan pool when idle
         if self.scan_executor:
             try:
-                self.scan_executor.shutdown(wait=False)
+                self.scan_executor.shutdown(wait=True)
             except Exception:
                 pass
             self.scan_executor = None
@@ -1349,14 +1405,7 @@ class AnalysisWorker:
         """
         logger.warning("Recreating process pool due to broken workers...")
 
-        # Attempt graceful shutdown first
-        if self.executor:
-            try:
-                self.executor.shutdown(wait=False)
-            except Exception as e:
-                logger.warning(f"Error during executor shutdown: {e}")
-            self.executor = None
-            self.pool_active = False
+        self._force_shutdown_pool()
 
         # Small delay to allow cleanup
         time.sleep(2)
@@ -1364,6 +1413,19 @@ class AnalysisWorker:
         # Create fresh pool
         self._ensure_pool()
         logger.info(f"Process pool recreated with {NUM_WORKERS} workers")
+
+    def _force_shutdown_pool(self):
+        """Force worker teardown and reset the normal pool state."""
+        executor = self.executor
+        self.executor = None
+        self.pool_active = False
+        _force_shutdown_executor(executor)
+
+    def _force_shutdown_scan_pool(self):
+        """Force worker teardown and reset the scan pool state."""
+        executor = self.scan_executor
+        self.scan_executor = None
+        _force_shutdown_executor(executor)
     
     def _cleanup_stale_processing(self):
         """Reset tracks stuck in 'processing' status (from crashed workers).
@@ -1824,12 +1886,7 @@ class AnalysisWorker:
                     failed += 1
                     logger.error(f"✗ Batch timeout (no penalty): {track_info[1]}")
             # Restart the pool to evict any stuck worker processes
-            try:
-                self.executor.shutdown(wait=False)
-            except Exception:
-                pass
-            self.executor = None
-            self.pool_active = False
+            self._force_shutdown_pool()
 
         elapsed = time.time() - start_time
         rate = len(tracks) / elapsed if elapsed > 0 else 0
@@ -2078,12 +2135,7 @@ class AnalysisWorker:
                     """, (tid,))
             self.db.commit()
             logger.error("Scan pool crash/timeout -- reset remaining tracks to pending")
-            try:
-                if self.scan_executor:
-                    self.scan_executor.shutdown(wait=False)
-            except Exception:
-                pass
-            self.scan_executor = None
+            self._force_shutdown_scan_pool()
         except Exception as e:
             logger.error(f"Scan validation failed: {e}")
             self.db.rollback()
@@ -2113,4 +2165,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/services/audio-analyzer/test_analyzer.py
+++ b/services/audio-analyzer/test_analyzer.py
@@ -8,6 +8,15 @@ Or: cd /mnt/storage/Projects/lidify/services/audio-analyzer && python3 test_anal
 import unittest
 import re
 import os
+import ast
+import logging
+import multiprocessing
+import time
+import types
+
+
+def _sleep_for_teardown_test():
+    time.sleep(30)
 
 
 class TestAnalyzerOptimisticLocking(unittest.TestCase):
@@ -53,6 +62,153 @@ class TestAnalyzerOptimisticLocking(unittest.TestCase):
         """_save_failed should check cursor.rowcount after UPDATE"""
         method = self._extract_method('_save_failed')
         self.assertIn('rowcount', method, "_save_failed missing rowcount check")
+
+
+class FakeProcess:
+    def __init__(self, survives_terminate=False):
+        self.pid = 123
+        self.alive = True
+        self.survives_terminate = survives_terminate
+        self.terminated = False
+        self.killed = False
+        self.join_timeouts = []
+
+    def is_alive(self):
+        return self.alive
+
+    def terminate(self):
+        self.terminated = True
+        if not self.survives_terminate:
+            self.alive = False
+
+    def kill(self):
+        self.killed = True
+        self.alive = False
+
+    def join(self, timeout=None):
+        self.join_timeouts.append(timeout)
+
+
+class FakeExecutor:
+    def __init__(self, processes):
+        self._processes = {index: process for index, process in enumerate(processes)}
+        self.shutdown_calls = []
+
+    def shutdown(self, **kwargs):
+        self.shutdown_calls.append(kwargs)
+
+
+class CompatibleExecutor:
+    """Simulate Python versions whose shutdown lacks cancel_futures."""
+
+    def __init__(self):
+        self.shutdown_calls = []
+
+    def shutdown(self, **kwargs):
+        self.shutdown_calls.append(kwargs)
+        if 'cancel_futures' in kwargs:
+            raise TypeError('cancel_futures is unsupported')
+
+
+class TestForcedExecutorTeardown(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        analyzer_path = os.path.join(os.path.dirname(__file__), 'analyzer.py')
+        with open(analyzer_path, 'r') as source_file:
+            tree = ast.parse(source_file.read())
+        names = {'PROCESS_TERMINATE_WAIT_SECONDS', 'PROCESS_KILL_WAIT_SECONDS'}
+        nodes = [
+            node for node in tree.body
+            if (isinstance(node, ast.FunctionDef) and node.name == '_force_shutdown_executor')
+            or (isinstance(node, ast.Assign) and any(
+                isinstance(target, ast.Name) and target.id in names
+                for target in node.targets
+            ))
+        ]
+        module = types.ModuleType('teardown_under_test')
+        module.logger = logging.getLogger('teardown-test')
+        exec(compile(ast.Module(body=nodes, type_ignores=[]), analyzer_path, 'exec'), module.__dict__)
+        cls.teardown = staticmethod(module._force_shutdown_executor)
+
+    def test_terminates_workers_and_cancels_queued_futures(self):
+        process = FakeProcess()
+        executor = FakeExecutor([process])
+
+        self.teardown(executor)
+
+        self.assertEqual(executor.shutdown_calls, [{'wait': False, 'cancel_futures': True}])
+        self.assertTrue(process.terminated)
+        self.assertFalse(process.killed)
+        self.assertFalse(process.alive)
+        self.assertTrue(all(timeout is not None for timeout in process.join_timeouts))
+
+    def test_kills_worker_only_when_terminate_does_not_stop_it(self):
+        process = FakeProcess(survives_terminate=True)
+
+        self.teardown(FakeExecutor([process]))
+
+        self.assertTrue(process.terminated)
+        self.assertTrue(process.killed)
+        self.assertFalse(process.alive)
+
+    def test_falls_back_when_cancel_futures_is_unsupported(self):
+        executor = CompatibleExecutor()
+
+        self.teardown(executor)
+
+        self.assertEqual(executor.shutdown_calls, [
+            {'wait': False, 'cancel_futures': True},
+            {'wait': False},
+        ])
+
+    def test_executor_without_private_process_mapping_is_supported(self):
+        executor = CompatibleExecutor()
+
+        self.teardown(executor)
+
+        self.assertEqual(executor.shutdown_calls[-1], {'wait': False})
+
+    def test_terminates_real_worker_process(self):
+        process = multiprocessing.Process(target=_sleep_for_teardown_test)
+        process.start()
+        self.addCleanup(lambda: process.kill() if process.is_alive() else None)
+
+        self.teardown(FakeExecutor([process]))
+
+        self.assertFalse(process.is_alive())
+        self.assertIsNotNone(process.exitcode)
+
+    def test_pool_helpers_reset_state(self):
+        calls = []
+        worker = types.SimpleNamespace(
+            executor=FakeExecutor([]),
+            scan_executor=FakeExecutor([]),
+            pool_active=True,
+        )
+
+        def force_shutdown(executor):
+            calls.append(executor)
+
+        analyzer_path = os.path.join(os.path.dirname(__file__), 'analyzer.py')
+        with open(analyzer_path, 'r') as source_file:
+            tree = ast.parse(source_file.read())
+        worker_class = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == 'AnalysisWorker')
+        helpers = [
+            node for node in worker_class.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name in {'_force_shutdown_pool', '_force_shutdown_scan_pool'}
+        ]
+        module = types.ModuleType('pool_helpers_under_test')
+        module._force_shutdown_executor = force_shutdown
+        exec(compile(ast.Module(body=helpers, type_ignores=[]), analyzer_path, 'exec'), module.__dict__)
+
+        module._force_shutdown_pool(worker)
+        module._force_shutdown_scan_pool(worker)
+
+        self.assertIsNone(worker.executor)
+        self.assertIsNone(worker.scan_executor)
+        self.assertFalse(worker.pool_active)
+        self.assertEqual(len(calls), 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Fixes a recovery-path memory leak in the audio analyzer. Timed-out or broken `ProcessPoolExecutor` pools previously used nonblocking cleanup and then lost their reference while TensorFlow/Essentia child workers could remain alive. Repeated recovery cycles accumulated workers until the container OOMed.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Documentation update
- [ ] Code cleanup / refactoring
- [ ] Other (please describe):

## Related Issues
Fixes #220

## Changes Made
- Add guarded, centralized forced recovery teardown for `ProcessPoolExecutor` instances.
- Cancel pending work where supported, terminate and bounded-join active workers, then kill only final survivors.
- Apply this only to timeout/broken/stale recovery paths for both analysis and scan pools; normal idle cleanup remains graceful.
- Add regression coverage for termination, kill escalation, compatibility fallback, absent private process mapping, and analyzer state reset.

## Testing Done
- [ ] Tested locally with Docker
- [x] Tested specific functionality: `cd services/audio-analyzer && python3 test_analyzer.py` (10 tests passed)
- [x] `python3 -m py_compile analyzer.py test_analyzer.py`
- [x] `git diff --check`

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My changes don't introduce new warnings
- [x] This PR targets the `main` branch