### PR TITLE
fix(subsonic): treat empty query as browse-all in search2/search3

### DIFF
--- a/backend/src/routes/subsonic/search.ts
+++ b/backend/src/routes/subsonic/search.ts
@@ -10,7 +10,8 @@ export const searchRouter = Router();
 // ===================== SEARCH =====================
 
 searchRouter.all(["/search3.view", "/search2.view", "/search.view"], wrap(async (req, res) => {
-    const query = (req.query.query as string | undefined) ?? "";
+    let query = (req.query.query as string | undefined) ?? "";
+    if (/^["'\s]*$/.test(query)) query = "";
 
     const artistCount = clamp(parseIntParam(req.query.artistCount as string | undefined, 20), 0, 500);
     const albumCount  = clamp(parseIntParam(req.query.albumCount  as string | undefined, 20), 0, 500);
@@ -22,10 +23,6 @@ searchRouter.all(["/search3.view", "/search2.view", "/search.view"], wrap(async 
     const isSearch3 = req.path.startsWith("/search3");
     const isLegacySearch = req.path.startsWith("/search.") || req.path.startsWith("/search/") || req.path.startsWith("/search");
     const responseKey = isSearch3 ? "searchResult3" : isLegacySearch ? "searchResult" : "searchResult2";
-
-    if (!query.trim()) {
-        return subsonicOk(req, res, { [responseKey]: {} });
-    }
 
     const [artists, rawAlbums, tracks] = await Promise.all([
         artistCount > 0

--- a/backend/src/services/search.ts
+++ b/backend/src/services/search.ts
@@ -149,7 +149,7 @@ export class SearchService {
         offset = 0,
     }: SearchOptions): Promise<ArtistSearchResult[]> {
         if (!query || query.trim().length === 0) {
-            return [];
+            return this.searchArtistsFallback({ query: "", limit, offset });
         }
 
         const tsquery = this.queryToTsquery(query);
@@ -241,7 +241,7 @@ export class SearchService {
         offset = 0,
     }: SearchOptions): Promise<AlbumSearchResult[]> {
         if (!query || query.trim().length === 0) {
-            return [];
+            return this.searchAlbumsFallback({ query: "", limit, offset });
         }
 
         const tsquery = this.queryToTsquery(query);
@@ -348,7 +348,7 @@ export class SearchService {
         offset = 0,
     }: SearchOptions): Promise<TrackSearchResult[]> {
         if (!query || query.trim().length === 0) {
-            return [];
+            return this.searchTracksFallback({ query: "", limit, offset });
         }
 
         const tsquery = this.queryToTsquery(query);


### PR DESCRIPTION
## Description

Subsonic clients enumerate a library by calling `search3` with an empty query (`query=` or `query=""`). Kima returned nothing for that, so clients like Symfonium synced 0 tracks even though the library and every other endpoint work fine. This makes the empty query behave as "browse all", matching what Subsonic clients expect.

## Type of Change

-   [x] Bug fix (non-breaking change that fixes an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Enhancement (improvement to existing functionality)
-   [ ] Documentation update
-   [ ] Code cleanup / refactoring
-   [ ] Other (please describe):

## Related Issues

Fixes #223

## Changes Made

-   `routes/subsonic/search.ts`: normalize a quotes-only/whitespace query (e.g. `query=""`, which clients send as two literal quote chars) to an empty string, and drop the early return that short-circuited an empty query to an empty response.
-   `services/search.ts`: on an empty query, `searchArtists` / `searchAlbums` / `searchTracks` now return all items (respecting `count`/`offset`) via the existing `*Fallback` helpers, which already match-all on an empty query.
-   Podcast/episode/audiobook search left unchanged.

## Testing Done

-   [x] Tested locally with Docker
-   [x] Tested specific functionality:
    -   Built from `v1.9.0` against a ~600-track library.
    -   `search3?query=""` now returns all songs/albums/artists with working `songOffset`/`albumOffset`/`artistOffset` pagination.
    -   Normal text search (e.g. `query=adele`) still works unchanged.
    -   Symfonium syncs the full library end-to-end.

## Screenshots (if applicable)

<img width="1080" height="1342" alt="image" src="https://github.com/user-attachments/assets/77b9cefd-451a-49d5-a48e-a5bcad200584" />


## Checklist

-   [x] My code follows the project's code style
-   [x] I have tested my changes locally
-   [ ] I have updated documentation if needed
-   [x] My changes don't introduce new warnings
-   [x] This PR targets the `main` branch
