### PR TITLE
feat(auth): optional LDAP/LLDAP authentication with transparent fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Kima uses several sensitive environment variables. Never commit your `.env` file
 -   **Password changes** - Changing your password invalidates all existing sessions
 -   **Session cookies** - Secured with `httpOnly`, `sameSite=strict`, and `secure` (in production)
 -   **Encryption validation** - Encryption key is validated on startup to prevent insecure defaults
+-   **Optional LDAP/LLDAP support** - Kima can authenticate against an external LDAP directory (including LLDAP) as a fallback after local bcrypt auth. Set `LDAP_ENABLED=true` and configure `LDAP_URL`, `LDAP_BIND_DN`, `LDAP_BIND_PASSWORD`, `LDAP_BASE_DN`, and `LDAP_USER_FILTER`. Users who succeed via LDAP but do not exist locally are auto-provisioned with the role configured in `LDAP_DEFAULT_ROLE`. See `backend/.env.example` for a complete LLDAP sample.
 
 ### Webhook Security
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,74 @@
+# Kima Backend Configuration
+# Copy to .env and edit as needed
+
+# ==============================================================================
+# Database Configuration
+# ==============================================================================
+DATABASE_URL="postgresql://kima:***@localhost:5433/kima"
+
+# ==============================================================================
+# Redis Configuration
+# ==============================================================================
+REDIS_URL="redis://localhost:6380"
+
+# ==============================================================================
+# REQUIRED: Path to your music library
+# ==============================================================================
+MUSIC_PATH=/path/to/your/music
+
+# ==============================================================================
+# REQUIRED: Security Keys
+# ==============================================================================
+
+# Encryption key for sensitive data (API keys, passwords, 2FA secrets)
+# CRITICAL: You MUST set this before starting Kima
+# Generate with: openssl rand -base64 32
+SETTINGS_ENCRYPTION_KEY=
+
+# Session secret (auto-generated if not set)
+# Generate with: openssl rand -base64 32
+SESSION_SECRET=
+
+# JWT secret. If unset, SESSION_SECRET is used as a fallback.
+JWT_SECRET=
+
+# ==============================================================================
+# OPTIONAL: LDAP / LLDAP Authentication
+# ==============================================================================
+# When LDAP_ENABLED is "true", Kima first tries local bcrypt auth and falls back
+# to the configured LDAP directory. Successful LDAP logins for unknown usernames
+# auto-provision a local user with the configured default role. Set to "false"
+# or leave unset to use local authentication only.
+#
+# Example values for an LLDAP server:
+#   LDAP_URL=ldap://192.168.68.71:3890
+#   LDAP_BIND_DN=uid=admin,ou=people,dc=headoverhalls,dc=net
+#   LDAP_BIND_PASSWORD=change-me
+#   LDAP_BASE_DN=ou=people,dc=headoverhalls,dc=net
+#   LDAP_USER_FILTER=(uid={username})
+#   LDAP_USERNAME_ATTRIBUTE=uid
+#   LDAP_DEFAULT_ROLE=user
+
+LDAP_ENABLED=false
+LDAP_URL=
+LDAP_BIND_DN=
+LDAP_BIND_PASSWORD=
+LDAP_BASE_DN=
+LDAP_USER_FILTER=(uid={username})
+LDAP_USERNAME_ATTRIBUTE=uid
+LDAP_DEFAULT_ROLE=user
+
+# ==============================================================================
+# OPTIONAL: Customize these if needed
+# ==============================================================================
+
+# Port the backend listens on (default: 3006)
+PORT=3006
+
+# Logging level (default: debug in development, warn in production)
+# Options: debug, info, warn, error, silent
+LOG_LEVEL=debug
+
+# Allowed CORS origins. In development this defaults to allowing all origins.
+# Example: ALLOWED_ORIGINS=https://kima.example.com,https://app.kima.example.com
+ALLOWED_ORIGINS=

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
                 "helmet": "^7.1.0",
                 "ioredis": "^5.10.0",
                 "jsonwebtoken": "^9.0.2",
+                "ldapts": "^8.1.8",
                 "multer": "^2.1.0",
                 "music-metadata": "^11.10.0",
                 "node-cron": "^4.2.1",
@@ -5041,6 +5042,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -6446,6 +6448,18 @@
             "dependencies": {
                 "jwa": "^2.0.1",
                 "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/ldapts": {
+            "version": "8.1.8",
+            "resolved": "https://registry.npmjs.org/ldapts/-/ldapts-8.1.8.tgz",
+            "integrity": "sha512-Wpdvo+/0DREIynYf2he2efHtjptr5zD7dpesSkZWJqfQdMEgSTytEIsSZVuoDSiiE1+SpXf3emZ7ewxGBTo7Pw==",
+            "license": "MIT",
+            "dependencies": {
+                "strict-event-emitter-types": "2.0.0"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/leven": {
@@ -8108,6 +8122,12 @@
             "engines": {
                 "node": ">=10.0.0"
             }
+        },
+        "node_modules/strict-event-emitter-types": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+            "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+            "license": "ISC"
         },
         "node_modules/string_decoder": {
             "version": "1.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,7 @@
         "helmet": "^7.1.0",
         "ioredis": "^5.10.0",
         "jsonwebtoken": "^9.0.2",
+        "ldapts": "^8.1.8",
         "multer": "^2.1.0",
         "music-metadata": "^11.10.0",
         "node-cron": "^4.2.1",

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -6,6 +6,9 @@ import packageJson from "../package.json";
 
 dotenv.config();
 
+// Import LDAP config to ensure it is validated and logged on startup
+import "./config/ldap";
+
 // Validate critical environment variables on startup
 const envSchema = z.object({
     DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),

--- a/backend/src/config/ldap.ts
+++ b/backend/src/config/ldap.ts
@@ -1,0 +1,76 @@
+import { logger } from "../utils/logger";
+
+/**
+ * Optional LDAP/LLDAP authentication configuration.
+ *
+ * All LDAP features are opt-in via environment variables. When LDAP_ENABLED
+ * is not set to "true", Kima behaves exactly as before and only uses local
+ * bcrypt authentication.
+ *
+ * Environment variables:
+ *   LDAP_ENABLED             - "true" to enable LDAP fallback
+ *   LDAP_URL                   - LDAP server URL, e.g. ldap://192.168.68.71:3890
+ *   LDAP_BIND_DN               - Service account DN for directory lookups
+ *   LDAP_BIND_PASSWORD         - Service account password
+ *   LDAP_BASE_DN               - Base DN for user searches
+ *   LDAP_USER_FILTER           - Filter template, e.g. (uid={username})
+ *   LDAP_USERNAME_ATTRIBUTE    - Attribute used for the local username (default: uid)
+ *   LDAP_DEFAULT_ROLE          - Role assigned to auto-provisioned users (default: user)
+ */
+export interface LdapConfig {
+    enabled: boolean;
+    url: string;
+    bindDn: string;
+    bindPassword: string;
+    baseDn: string;
+    userFilter: string;
+    usernameAttribute: string;
+    defaultRole: "user" | "admin";
+}
+
+function parseBoolean(value: string | undefined): boolean {
+    return value === "true" || value === "1" || value === "yes";
+}
+
+export function getLdapConfig(): LdapConfig {
+    const enabled = parseBoolean(process.env.LDAP_ENABLED);
+
+    const defaultRole = process.env.LDAP_DEFAULT_ROLE;
+    const role: "user" | "admin" =
+        defaultRole === "admin" ? "admin" : "user";
+
+    return {
+        enabled,
+        url: process.env.LDAP_URL || "",
+        bindDn: process.env.LDAP_BIND_DN || "",
+        bindPassword: process.env.LDAP_BIND_PASSWORD || "",
+        baseDn: process.env.LDAP_BASE_DN || "",
+        userFilter: process.env.LDAP_USER_FILTER || "(uid={username})",
+        usernameAttribute: process.env.LDAP_USERNAME_ATTRIBUTE || "uid",
+        defaultRole: role,
+    };
+}
+
+function logLdapConfig(config: LdapConfig) {
+    if (!config.enabled) return;
+
+    const missing: string[] = [];
+    if (!config.url) missing.push("LDAP_URL");
+    if (!config.bindDn) missing.push("LDAP_BIND_DN");
+    if (!config.bindPassword) missing.push("LDAP_BIND_PASSWORD");
+    if (!config.baseDn) missing.push("LDAP_BASE_DN");
+
+    if (missing.length > 0) {
+        logger.error(
+            `[LDAP] LDAP_ENABLED is true but required variables are missing: ${missing.join(", ")}`
+        );
+    } else {
+        logger.info(
+            `[LDAP] LDAP authentication enabled against ${config.url} (base DN: ${config.baseDn})`
+        );
+    }
+}
+
+// Module-level config is evaluated once at startup for validation/logging.
+export const ldapConfig = getLdapConfig();
+logLdapConfig(ldapConfig);

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -14,6 +14,8 @@ import {
     generateRefreshToken,
 } from "../middleware/auth";
 import { encrypt, decrypt } from "../utils/encryption";
+import { authenticateLdapUser, isLdapEnabled } from "../services/ldapAuth";
+import { ldapConfig } from "../config/ldap";
 
 const router = Router();
 
@@ -38,14 +40,71 @@ router.post("/login", async (req, res) => {
         // Timing-safe: always run bcrypt to prevent username enumeration
         const dummyHash = "$2b$10$invalidhashfortimingsafety.00000000000000000000";
         const valid = await bcrypt.compare(password, user?.passwordHash ?? dummyHash);
-        if (!user || !valid) {
+
+        let authenticatedUser = user && valid ? user : null;
+
+        // LDAP fallback: if local auth fails and LDAP is enabled, try directory auth.
+        // This preserves local auth behavior while allowing external LLDAP accounts.
+        if (!authenticatedUser && isLdapEnabled()) {
+            logger.debug(`[AUTH] Local auth failed for ${username}; attempting LDAP`);
+            const ldapResult = await authenticateLdapUser(username, password);
+
+            if (ldapResult.success && ldapResult.profile) {
+                const profile = ldapResult.profile;
+                logger.debug(`[AUTH] LDAP authentication succeeded for ${profile.username}`);
+
+                // Look up an existing local account for this LDAP username.
+                let localUser = await prisma.user.findUnique({
+                    where: { username: profile.username },
+                });
+
+                // Auto-provision a local user if none exists so that tokens,
+                // settings, and relationships work without schema changes.
+                if (!localUser) {
+                    logger.info(
+                        `[AUTH] Auto-provisioning local user from LDAP: ${profile.username}`
+                    );
+                    const placeholderHash = await bcrypt.hash(
+                        crypto.randomBytes(32).toString("hex"),
+                        10
+                    );
+                    localUser = await prisma.user.create({
+                        data: {
+                            username: profile.username,
+                            passwordHash: placeholderHash,
+                            role: ldapConfig.defaultRole,
+                            onboardingComplete: false,
+                        },
+                    });
+
+                    // Create default settings for the provisioned user
+                    await prisma.userSettings.create({
+                        data: {
+                            userId: localUser.id,
+                            playbackQuality: "original",
+                            wifiOnly: false,
+                            offlineEnabled: false,
+                            maxCacheSizeMb: 10240,
+                        },
+                    });
+                }
+
+                authenticatedUser = localUser;
+            } else {
+                logger.debug(
+                    `[AUTH] LDAP authentication failed for ${username}: ${ldapResult.error}`
+                );
+            }
+        }
+
+        if (!authenticatedUser) {
             logger.debug(`[AUTH] Invalid credentials for: ${username}`);
             return res.status(401).json({ error: "Invalid credentials" });
         }
         logger.debug(`[AUTH] Password verified for user: ${username}`);
 
         // Check if 2FA is enabled
-        if (user.twoFactorEnabled && user.twoFactorSecret) {
+        if (authenticatedUser.twoFactorEnabled && authenticatedUser.twoFactorSecret) {
             if (!token) {
                 return res.status(200).json({
                     requires2FA: true,
@@ -56,8 +115,8 @@ router.post("/login", async (req, res) => {
             // Check if it's a recovery code
             const isRecoveryCode = /^[A-F0-9]{8}$/i.test(token);
 
-            if (isRecoveryCode && user.twoFactorRecoveryCodes) {
-                const encryptedCodes = user.twoFactorRecoveryCodes;
+            if (isRecoveryCode && authenticatedUser.twoFactorRecoveryCodes) {
+                const encryptedCodes = authenticatedUser.twoFactorRecoveryCodes;
                 const decryptedCodes = decrypt2FASecret(encryptedCodes);
                 const hashedCodes = decryptedCodes.split(",");
 
@@ -75,7 +134,7 @@ router.post("/login", async (req, res) => {
 
                 hashedCodes.splice(codeIndex, 1);
                 await prisma.user.update({
-                    where: { id: user.id },
+                    where: { id: authenticatedUser.id },
                     data: {
                         twoFactorRecoveryCodes: encrypt2FASecret(
                             hashedCodes.join(",")
@@ -84,7 +143,7 @@ router.post("/login", async (req, res) => {
                 });
             } else {
                 // Verify TOTP token
-                const secret = decrypt2FASecret(user.twoFactorSecret);
+                const secret = decrypt2FASecret(authenticatedUser.twoFactorSecret);
                 const verified = speakeasy.totp.verify({
                     secret,
                     encoding: "base32",
@@ -100,23 +159,23 @@ router.post("/login", async (req, res) => {
 
         // Generate JWT tokens
         const jwtToken = generateToken({
-            id: user.id,
-            username: user.username,
-            role: user.role,
-            tokenVersion: user.tokenVersion,
+            id: authenticatedUser.id,
+            username: authenticatedUser.username,
+            role: authenticatedUser.role,
+            tokenVersion: authenticatedUser.tokenVersion,
         });
         const refreshToken = generateRefreshToken({
-            id: user.id,
-            tokenVersion: user.tokenVersion,
+            id: authenticatedUser.id,
+            tokenVersion: authenticatedUser.tokenVersion,
         });
 
         res.json({
             token: jwtToken,
             refreshToken: refreshToken,
             user: {
-                id: user.id,
-                username: user.username,
-                role: user.role,
+                id: authenticatedUser.id,
+                username: authenticatedUser.username,
+                role: authenticatedUser.role,
             },
         });
     } catch (err) {

--- a/backend/src/services/__tests__/ldapAuth.test.ts
+++ b/backend/src/services/__tests__/ldapAuth.test.ts
@@ -1,0 +1,174 @@
+/**
+ * LDAP authentication service tests
+ *
+ * These tests mock the `ldapts` Client to exercise success, failure, invalid
+ * credentials, ambiguous search results, and disabled LDAP paths without
+ * requiring a real directory server.
+ */
+
+jest.mock("ldapts");
+
+import { Client } from "ldapts";
+import { authenticateLdapUser, buildUserFilter } from "../ldapAuth";
+
+const MockedClient = jest.mocked(Client);
+
+describe("buildUserFilter", () => {
+    it("substitutes the username into the filter template", () => {
+        process.env.LDAP_USER_FILTER = "(uid={username})";
+        expect(buildUserFilter("testuser")).toBe("(uid=testuser)");
+    });
+
+    it("escapes special LDAP characters", () => {
+        process.env.LDAP_USER_FILTER = "(uid={username})";
+        expect(buildUserFilter("user*name")).toBe("(uid=user\\*name)");
+    });
+});
+
+describe("authenticateLdapUser", () => {
+    const bindMock = jest.fn();
+    const searchMock = jest.fn();
+    const unbindMock = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Default environment: LDAP enabled with minimal config
+        process.env.LDAP_ENABLED = "true";
+        process.env.LDAP_URL = "ldap://192.168.68.71:3890";
+        process.env.LDAP_BIND_DN = "uid=admin,ou=people,dc=headoverhalls,dc=net";
+        process.env.LDAP_BIND_PASSWORD = "admin-secret";
+        process.env.LDAP_BASE_DN = "ou=people,dc=headoverhalls,dc=net";
+        process.env.LDAP_USER_FILTER = "(uid={username})";
+        process.env.LDAP_USERNAME_ATTRIBUTE = "uid";
+        process.env.LDAP_DEFAULT_ROLE = "user";
+
+        MockedClient.mockImplementation(() => {
+            return {
+                bind: bindMock,
+                search: searchMock,
+                unbind: unbindMock,
+            } as unknown as Client;
+        });
+    });
+
+    afterAll(() => {
+        delete process.env.LDAP_ENABLED;
+        delete process.env.LDAP_URL;
+        delete process.env.LDAP_BIND_DN;
+        delete process.env.LDAP_BIND_PASSWORD;
+        delete process.env.LDAP_BASE_DN;
+        delete process.env.LDAP_USER_FILTER;
+        delete process.env.LDAP_USERNAME_ATTRIBUTE;
+        delete process.env.LDAP_DEFAULT_ROLE;
+    });
+
+    it("returns success with profile on valid credentials", async () => {
+        bindMock
+            .mockResolvedValueOnce(undefined) // service bind
+            .mockResolvedValueOnce(undefined); // user bind
+
+        searchMock.mockResolvedValue({
+            searchEntries: [
+                {
+                    dn: "uid=testuser,ou=people,dc=headoverhalls,dc=net",
+                    uid: "testuser",
+                    displayName: "Test User",
+                    mail: "test@example.com",
+                },
+            ],
+        });
+
+        const result = await authenticateLdapUser("testuser", "testing123");
+
+        expect(result.success).toBe(true);
+        expect(result.profile).toEqual({
+            username: "testuser",
+            dn: "uid=testuser,ou=people,dc=headoverhalls,dc=net",
+            displayName: "Test User",
+            email: "test@example.com",
+        });
+        expect(bindMock).toHaveBeenNthCalledWith(
+            1,
+            "uid=admin,ou=people,dc=headoverhalls,dc=net",
+            "admin-secret"
+        );
+        expect(bindMock).toHaveBeenNthCalledWith(
+            2,
+            "uid=testuser,ou=people,dc=headoverhalls,dc=net",
+            "testing123"
+        );
+    });
+
+    it("returns failure when user is not found", async () => {
+        bindMock.mockResolvedValueOnce(undefined);
+        searchMock.mockResolvedValue({ searchEntries: [] });
+
+        const result = await authenticateLdapUser("unknown", "password");
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe("User not found");
+    });
+
+    it("returns failure when user bind rejects the password", async () => {
+        bindMock
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(new Error("Invalid credentials"));
+
+        searchMock.mockResolvedValue({
+            searchEntries: [
+                {
+                    dn: "uid=testuser,ou=people,dc=headoverhalls,dc=net",
+                    uid: "testuser",
+                },
+            ],
+        });
+
+        const result = await authenticateLdapUser("testuser", "wrongpassword");
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe("LDAP authentication failed");
+    });
+
+    it("returns failure when search returns ambiguous results", async () => {
+        bindMock.mockResolvedValueOnce(undefined);
+        searchMock.mockResolvedValue({
+            searchEntries: [
+                { dn: "uid=testuser,ou=people,dc=headoverhalls,dc=net", uid: "testuser" },
+                { dn: "uid=testuser2,ou=people,dc=headoverhalls,dc=net", uid: "testuser2" },
+            ],
+        });
+
+        const result = await authenticateLdapUser("testuser", "password");
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe("Ambiguous user search result");
+    });
+
+    it("returns failure when LDAP is disabled", async () => {
+        process.env.LDAP_ENABLED = "false";
+
+        const result = await authenticateLdapUser("testuser", "password");
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe("LDAP is not enabled");
+        expect(MockedClient).not.toHaveBeenCalled();
+    });
+
+    it("returns failure when service account bind fails", async () => {
+        bindMock.mockRejectedValueOnce(new Error("Service bind failed"));
+
+        const result = await authenticateLdapUser("testuser", "password");
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe("LDAP authentication failed");
+    });
+
+    it("unbinds both clients even on failure", async () => {
+        bindMock.mockRejectedValueOnce(new Error("Service bind failed"));
+
+        await authenticateLdapUser("testuser", "password");
+
+        expect(unbindMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/backend/src/services/ldapAuth.ts
+++ b/backend/src/services/ldapAuth.ts
@@ -1,0 +1,188 @@
+/**
+ * LDAP/LLDAP authentication service.
+ *
+ * This module provides an optional, opt-in LDAP authentication backend. It is
+ * designed to work with standard LDAP directories as well as LLDAP. The flow:
+ *
+ *   1. Bind with the configured service account.
+ *   2. Search for the user by the configured filter (default (uid={username})).
+ *   3. Attempt a second bind with the user's DN and supplied password.
+ *   4. On success, return a normalized profile used by the local auth route.
+ *
+ * LDAP is only attempted when the `LDAP_ENABLED` environment variable is set to
+ * "true" and the local bcrypt check fails. The module does not alter the Prisma
+ * schema; auto-provisioned local users get a random placeholder password hash so
+ * the non-null `passwordHash` constraint remains satisfied.
+ */
+
+import { Client } from "ldapts";
+import { getLdapConfig, ldapConfig } from "../config/ldap";
+import { logger } from "../utils/logger";
+
+export interface LdapProfile {
+    /** Normalized username used for the local Kima account */
+    username: string;
+    /** Display name from the directory (optional) */
+    displayName?: string;
+    /** Email address from the directory (optional) */
+    email?: string;
+    /** Full distinguished name of the LDAP entry */
+    dn: string;
+}
+
+export interface LdapAuthResult {
+    /** Whether authentication succeeded */
+    success: boolean;
+    /** User profile when authentication succeeded */
+    profile?: LdapProfile;
+    /** Human-readable failure reason (never includes credentials) */
+    error?: string;
+}
+
+/**
+ * Build the LDAP search filter by substituting the escaped username into the
+ * configured filter template.
+ */
+export function buildUserFilter(username: string): string {
+    const config = getLdapConfig();
+    const escaped = username.replace(/([\\*()\0])/g, "\\$1");
+    return config.userFilter.replace(/\{username\}/g, escaped);
+}
+
+/**
+ * Extract a single string attribute value from an LDAP entry.
+ */
+function getAttributeValue(
+    attributes: Record<string, string | string[]> | undefined,
+    name: string
+): string | undefined {
+    if (!attributes) return undefined;
+    const value = attributes[name];
+    if (Array.isArray(value)) return value[0];
+    return typeof value === "string" ? value : undefined;
+}
+
+function createClient(url: string): Client {
+    return new Client({
+        url,
+    });
+}
+
+/**
+ * Attempt to authenticate a user against the configured LDAP/LLDAP server.
+ *
+ * @param username The username (e.g. the LLDAP uid value)
+ * @param password The user's plaintext password
+ * @returns LdapAuthResult with profile on success, error reason on failure
+ */
+export async function authenticateLdapUser(
+    username: string,
+    password: string
+): Promise<LdapAuthResult> {
+    const config = getLdapConfig();
+
+    if (!config.enabled) {
+        return { success: false, error: "LDAP is not enabled" };
+    }
+
+    if (!username || !password) {
+        return { success: false, error: "Username and password are required" };
+    }
+
+    let searchClient: Client | undefined;
+    let userClient: Client | undefined;
+
+    try {
+        searchClient = createClient(config.url);
+        await searchClient.bind(config.bindDn, config.bindPassword);
+
+        const filter = buildUserFilter(username);
+        logger.debug(`[LDAP] Searching for user with filter: ${filter}`);
+
+        const { searchEntries } = await searchClient.search(
+            config.baseDn,
+            {
+                scope: "sub",
+                filter,
+                attributes: [
+                    "dn",
+                    config.usernameAttribute,
+                    "displayName",
+                    "mail",
+                    "email",
+                ],
+                sizeLimit: 2,
+            }
+        );
+
+        if (searchEntries.length === 0) {
+            logger.debug(`[LDAP] No user found for filter: ${filter}`);
+            return { success: false, error: "User not found" };
+        }
+
+        if (searchEntries.length > 1) {
+            logger.warn(
+                `[LDAP] Filter ${filter} returned ${searchEntries.length} entries; expected one`
+            );
+            return { success: false, error: "Ambiguous user search result" };
+        }
+
+        const entry = searchEntries[0];
+        const dn = entry.dn;
+
+        if (!dn) {
+            logger.error("[LDAP] Found entry has no distinguished name");
+            return { success: false, error: "Invalid LDAP entry" };
+        }
+
+        // Verify credentials by binding as the user with their password.
+        userClient = createClient(config.url);
+        await userClient.bind(dn, password);
+
+        const rawUsername =
+            getAttributeValue(entry as Record<string, string | string[]>, config.usernameAttribute) ||
+            username;
+
+        const profile: LdapProfile = {
+            username: rawUsername.toLowerCase(),
+            dn,
+            displayName: getAttributeValue(
+                entry as Record<string, string | string[]>,
+                "displayName"
+            ),
+            email:
+                getAttributeValue(entry as Record<string, string | string[]>, "mail") ||
+                getAttributeValue(entry as Record<string, string | string[]>, "email"),
+        };
+
+        logger.info(`[LDAP] Successful authentication for ${profile.username}`);
+        return { success: true, profile };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(`[LDAP] Authentication error for ${username}: ${message}`);
+        return { success: false, error: "LDAP authentication failed" };
+    } finally {
+        try {
+            await searchClient?.unbind();
+        } catch {
+            // Ignore unbind errors
+        }
+        try {
+            await userClient?.unbind();
+        } catch {
+            // Ignore unbind errors
+        }
+    }
+}
+
+/**
+ * Check whether LDAP fallback is enabled and minimally configured.
+ * Used by the auth route to decide whether to attempt LDAP after local auth
+ * failure.
+ */
+export function isLdapEnabled(): boolean {
+    return getLdapConfig().enabled;
+}
+
+// Re-export the module-level config so consumers can read default values.
+export { ldapConfig };


### PR DESCRIPTION
This PR adds optional LDAP/LLDAP authentication as a transparent fallback to local bcrypt auth.\n\n- Adds ldapts dependency and opt-in env-based LDAP config\n- Binds/searches LLDAP via configurable filter, verifies password with user-DN rebind\n- Auto-provisions local User + UserSettings on first LDAP login\n- Preserves timing-safe local auth behavior and local admin fallback\n- Includes unit tests and README/.env.example documentation\n\nAll changes are opt-in; default installs continue to use local auth only.